### PR TITLE
Improvements to control structures, migration of some code from Rust to Forth, and updates to regression tests.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'f2'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=f2",
+                    "--package=f2"
+                ],
+                "filter": {
+                    "name": "f2",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'f2'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=f2",
+                    "--package=f2"
+                ],
+                "filter": {
+                    "name": "f2",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,8 +5,8 @@ use crate::messages::DebugLevel;
 
 use ::clap::{arg, Command};
 
-const VERSION: &str = "alpha.24.2.20";
-const WELCOME_MESSAGE: &str = "Welcome to tForth.";
+const VERSION: &str = "alpha.24.3.1";
+const WELCOME_MESSAGE: &str = "Welcome to f2.";
 const EXIT_MESSAGE: &str = "Finished";
 const DEFAULT_CORE: [&str; 2] = ["~/.tforth/corelib.fs", "src/corelib.fs"];
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,12 +8,18 @@ use ::clap::{arg, Command};
 const VERSION: &str = "alpha.24.3.1";
 const WELCOME_MESSAGE: &str = "Welcome to f2.";
 const EXIT_MESSAGE: &str = "Finished";
-const DEFAULT_CORE: [&str; 2] = ["~/.tforth/corelib.fs", "src/corelib.fs"];
+const DEFAULT_CORE: [&str; 2] = ["~/.f2/corelib.fs", "src/corelib.fs"];
+
+macro_rules! push {
+    ($self:ident, $val:expr) => {
+        $self.stack_ptr -= 1;
+        $self.data[$self.stack_ptr] = $val;
+    };
+}
 
 pub struct Config {
     debug_level: DebugLevel,
     loaded_file: String,
-    loaded_core: bool,
     core_file: String,
     no_core: bool,
     pub run: bool,
@@ -24,7 +30,6 @@ impl Config {
         Config {
             debug_level: DebugLevel::Error,
             loaded_file: "".to_owned(),
-            loaded_core: false,
             core_file: DEFAULT_CORE[0].to_owned(),
             no_core: false,
             run: true,
@@ -79,38 +84,27 @@ impl Config {
     pub fn run_forth(&mut self) {
         // create and run the interpreter
         // return when finished
+        fn load_file(interpreter: &mut TF, file_name: &str) {
+            TF::u_set_string(
+                interpreter,
+                interpreter.data[interpreter.tmp_ptr] as usize,
+                file_name,
+            );
+            push!(interpreter, interpreter.data[interpreter.tmp_ptr]);
+            interpreter.f_include_file();
+        }
 
         let mut forth = TF::new();
         forth.cold_start();
+        if !self.no_core {
+            for path in DEFAULT_CORE {
+                load_file(&mut forth, &path);
+            }
+        }
+        if self.loaded_file != "" {
+            load_file(&mut forth, &self.loaded_file);
+        }
 
-        forth.msg.set_level(self.debug_level.clone());
-
-        /*         if !self.no_core {
-                   for path in DEFAULT_CORE {
-                       if forth.load_file(&path.to_owned()) {
-                           self.loaded_core = true;
-                           forth
-                               .msg
-                               .info("MAIN", "Loaded core dictionary", Some(&self.core_file));
-                           break;
-                       }
-                   }
-                   if !self.loaded_core {
-                       forth.msg.error(
-                           "MAIN",
-                           "Unable to load core dictionary",
-                           Some(&self.core_file),
-                       );
-                   }
-               }
-               if self.loaded_file != "" {
-                   if !forth.load_file(&self.loaded_file) {
-                       forth
-                           .msg
-                           .error("MAIN", "Unable to load userfile", Some(&self.loaded_file));
-                   }
-               }
-        */
         forth.set_abort_flag(false); // abort flag may have been set by load_file, but is no longer needed.
 
         println!("{WELCOME_MESSAGE} Version {VERSION}");

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,37 +80,37 @@ impl Config {
         // create and run the interpreter
         // return when finished
 
-        let mut forth = TF::new("Ok ");
+        let mut forth = TF::new();
         forth.cold_start();
 
         forth.msg.set_level(self.debug_level.clone());
 
-        if !self.no_core {
-            for path in DEFAULT_CORE {
-                if forth.load_file(&path.to_owned()) {
-                    self.loaded_core = true;
-                    forth
-                        .msg
-                        .info("MAIN", "Loaded core dictionary", Some(&self.core_file));
-                    break;
-                }
-            }
-            if !self.loaded_core {
-                forth.msg.error(
-                    "MAIN",
-                    "Unable to load core dictionary",
-                    Some(&self.core_file),
-                );
-            }
-        }
-        if self.loaded_file != "" {
-            if !forth.load_file(&self.loaded_file) {
-                forth
-                    .msg
-                    .error("MAIN", "Unable to load userfile", Some(&self.loaded_file));
-            }
-        }
-
+        /*         if !self.no_core {
+                   for path in DEFAULT_CORE {
+                       if forth.load_file(&path.to_owned()) {
+                           self.loaded_core = true;
+                           forth
+                               .msg
+                               .info("MAIN", "Loaded core dictionary", Some(&self.core_file));
+                           break;
+                       }
+                   }
+                   if !self.loaded_core {
+                       forth.msg.error(
+                           "MAIN",
+                           "Unable to load core dictionary",
+                           Some(&self.core_file),
+                       );
+                   }
+               }
+               if self.loaded_file != "" {
+                   if !forth.load_file(&self.loaded_file) {
+                       forth
+                           .msg
+                           .error("MAIN", "Unable to load userfile", Some(&self.loaded_file));
+                   }
+               }
+        */
         forth.set_abort_flag(false); // abort flag may have been set by load_file, but is no longer needed.
 
         println!("{WELCOME_MESSAGE} Version {VERSION}");

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -51,6 +51,11 @@
 : for here @ ['] >r , ; immediate
 : next ['] r> , LITERAL , 1 , ['] - , ['] dup , ['] 0= , BRANCH0 , here @ - , ['] drop , ; immediate
 
+: begin here @ ; immediate
+: until BRANCH0 , here @ - , ; immediate
+: while BRANCH0 , here @ 0 , ;  immediate
+: repeat BRANCH , swap here @ - , dup here @ swap - swap ! ; immediate
+
 : 1- ( n -- n-1 ) 1 - ;
 : 1+ ( n -- n+1 ) 1 + ;
 : negate ( n -- -n ) 0 swap - ;
@@ -65,14 +70,20 @@
 : min ( m n -- m | n ) 2dup < if drop else nip then ;
 : max ( m n -- m | n ) 2dup > if drop else nip then ;
 : abs ( n -- n | -n ) dup 0 < if -1 * then ;
+
+: space ( -- ) BL emit ;
+: spaces ( n -- ) 1- for space next ;
+
+\ Implementation of word
+: .word ( bp -- bp ) dup 1+ @ type space @ ;                \ prints a word name, given the preceding back pointer
+: words ( -- ) here @ 1- @ begin .word dup not until ;   \ loops through the words in the dictionary
+
 : dbg-debug 3 dbg ;
 : dbg-info 2 dbg ;
 : dbg-warning 1 dbg ;
 : dbg-quiet 0 dbg ;
-
 : debug show-stack step-on ;
-: space ( -- ) BL emit ;
-: spaces ( n -- ) 1- for space next ;
+
 \ : ?stack depth 0= if ." Stack underflow" abort then ;
 
 

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -41,7 +41,10 @@
 
 : .tmp tmp @ type ;
 : .pad pad @ type ;
+: ." s" .tmp ;
 
+: 1- ( n -- n-1 ) 1 - ;
+: 1+ ( n -- n+1 ) 1 + ;
 : negate ( n -- -n ) if 0 else -1 then ;
 : nip ( a b -- b ) swap drop ;
 : tuck ( a b -- b a b ) swap over ;
@@ -52,24 +55,23 @@
 : <> ( n -- n ) = 0= ;
 : min ( m n -- m | n ) 2dup < if drop else nip then ;
 : max ( m n -- m | n ) 2dup > if drop else nip then ;
-: abs (n -- n | -n ) dup 0 < if -1 * then ;
+: abs ( n -- n | -n ) dup 0 < if -1 * then ;
 : dbg-debug 3 dbg ;
 : dbg-info 2 dbg ;
 : dbg-warning 1 dbg ;
 : dbg-quiet 0 dbg ;
+
 : debug show-stack step-on ;
 : space ( -- ) BL emit ;
 : spaces ( n -- ) 1- for space next ;
-: 1- ( n -- n-1 ) 1 - ;
-: 1+ ( n -- n+1 ) 1 + ;
-: ?stack depth 0= if ." Stack underflow" abort then ;
+\ : ?stack depth 0= if ." Stack underflow" abort then ;
 
 
 : +! ( n addr -- ) dup @ rot + swap ! ;
 : ? ( addr -- ) @ . ;
 
 s" src/regression.fs" 
-: run-regression clear include-file ;
+: run-regression clear tmp @ include-file ;
 
 
 ( Application functions )
@@ -89,4 +91,4 @@ s" src/regression.fs"
             drop 1 
         then ;
 
-." Library loaded."
+ ." Library loaded."

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -133,7 +133,7 @@
     #tib @ >in @ < if FALSE else key TRUE then ;        \ otherwise push FALSE
 : strlen ( s -- n ) c@ ;                                \ return the count byte from the string
                                                 
-\ s" src/regression.fs" 
+\ s" src/regression.fs" drop drop
 \ : run-regression include ;
 
 

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -1,6 +1,6 @@
 ( Core word definitions )
 
-: negate ( n -- -n ) if -1 else 0 then ;
+: negate ( n -- -n ) if 0 else -1 then ;
 : nip ( a b -- b ) swap drop ;
 : tuck ( a b -- b a b ) swap over ;
 : pop ( a -- ) drop ;
@@ -18,15 +18,18 @@
 : debug show-stack step-on ;
 : bl 32 ; ( puts the character code for a space on the stack )
 : space ( -- ) bl emit ;
-: spaces ( n -- ) 1- for space emit next ;
+: spaces ( n -- ) 1- for space next ;
 : 1- ( n -- n-1 ) 1 - ;
 : 1+ ( n -- n+1 ) 1 + ;
-: endif then ; ( synonym for then, to allow if - else - endif conditionals )
 : ?stack depth 0= if ." Stack underflow" abort then ;
 
 
 : +! ( n addr -- ) dup @ rot + swap ! ;
 : ? ( addr -- ) @ . ;
+
+( File reader functions )
+: included tmp @ include-file ; \ include-file uses a string pointer on the stack to load a file
+: include 32 s-parse included ;
 
 s" src/regression.fs" 
 : run-regression clear include-file ;

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -29,7 +29,7 @@
 
 : text BL parse ;                                   \ Parser shortcut for space-delimited tokens
 : s-parse tmp @ swap parse-to ;                     \ Same as text, but loads to tmp instead of pad
-\ : s" ( delim -- s u ") tmp @ DQUOTE parse-to ;      \ Places a double-quoted string in tmp
+: s" ( delim -- s u ") tmp @ DQUOTE parse-to ;      \ Places a double-quoted string in tmp
 
 ( File reader functions )
 : included tmp @ include-file ; \ include-file uses a string pointer on the stack to load a file
@@ -41,10 +41,7 @@
 : recurse ( -- ) \ Simply compiles the cfa of the word being defined
     last @ 1 + , ; immediate \ last points to the latest nfa, so increment
 
-: .tmp tmp @ type ;
-: .pad pad @ type ;
-: ." s" .tmp ;
-: ' (') @ ;
+: ' (') @ ;                                            \ searches for a (postfix) word and returns its cfa or FALSE
 : ['] LITERAL , ' , ; immediate                        \ compiles a word's cfa into a definition as a literal
 : cfa>nfa 1 - ;                                        \ converts an cfa to an nfa
 : nfa>cfa 1 + ;                                        \ converts an nfa to a cfa
@@ -83,6 +80,10 @@
 : spaces ( n -- ) 1- for space next ;
 
 : type ( s -- ) ADDRESS_MASK and dup c@ dup rot + swap for dup i - 1+ c@ emit next drop BL emit ;
+
+: .tmp tmp @ type ;
+: .pad pad @ type ;
+: ." s" .tmp ;
 
 \ Implementation of word
 : .word ( bp -- bp ) dup 1+ @ type space @ ;             \ prints a word name, given the preceding back pointer

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -4,13 +4,16 @@
 
 1 dbg \ set debuglevel to warnings and errors
 
+0 constant FALSE
+-1 constant TRUE
+
 \ Constants referring to inner interpreter opcodes, which are typically compiled into definitions
 1000 constant BUILTIN
 1001 constant VARIABLE
 1002 constant CONSTANT
 1003 constant LITERAL
 1004 constant STRLIT
-1005 constant definition
+1005 constant DEFINITION
 1006 constant BRANCH
 1007 constant BRANCH0
 1008 constant ABORT
@@ -18,42 +21,59 @@
 
 72057594037927935 constant ADDRESS_MASK                      \ wipes any flags
 
-0 constant FALSE
--1 constant TRUE
-
 \ ASCII symbols that are useful for text processing
 32 constant BL
-34 constant DQUOTE
-39 constant SQUOTE
-41 constant RPAREN
+34 constant '"'
+39 constant '''
+41 constant ')'
+45 constant '-'
+58 constant ':'
+61 constant '='
+91 constant '['
+93 constant ']'
+
+\ create fn               \ make a definition for the word fn
+\ DEFINITION , 
+\ LITERAL , 1 ,
+
 
 : text BL parse ;                                   \ Parser shortcut for space-delimited tokens
 : s-parse tmp @ swap parse-to ;                     \ Same as text, but loads to tmp instead of pad
-: s" ( delim -- s u ") tmp @ DQUOTE parse-to ;      \ Places a double-quoted string in tmp
+: s" ( -- s u ") tmp @ '"' parse-to ;         \ Places a double-quoted string in tmp
 
 ( File reader functions )
 : included tmp @ include-file ; \ include-file uses a string pointer on the stack to load a file
 : include tmp @ 32 parse-to included ;
 
-( inner interpreter op codes, used by control structures )
+: [ FALSE state ! ; immediate                                \ Turns compile mode off
+: ] TRUE state ! ;                                  \ Turns compile mode on
 
 \ Untested implementation of recursion support
 : recurse ( -- ) \ Simply compiles the cfa of the word being defined
     last @ 1 + , ; immediate \ last points to the latest nfa, so increment
 
-: ' (') @ ;                                            \ searches for a (postfix) word and returns its cfa or FALSE
+: nip ( a b -- b ) swap drop ;
+: tuck ( a b -- b a b ) swap over ;
+
+: if BRANCH0 , here @  0 , ; immediate
+: else BRANCH , here @ 0 , swap dup here @ swap - swap ! ; immediate
+: then dup here @ swap - swap ! ; immediate
+
+: ' (') dup @ dup DEFINITION = if drop else nip then ; \ searches for a (postfix) word and returns its cfa or FALSE
+
 : ['] LITERAL , ' , ; immediate                        \ compiles a word's cfa into a definition as a literal
 : cfa>nfa 1 - ;                                        \ converts an cfa to an nfa
 : nfa>cfa 1 + ;                                        \ converts an nfa to a cfa
 : bp>nfa 1 + ;                                         \ from preceding back pointer to nfa
-: bp>cfa 2 + ;                                         \ from preceding back pointer to cfa
-
- : if BRANCH0 , here @  0 , ; immediate
- : else BRANCH , here @ 0 , swap dup here @ swap - swap ! ; immediate
- : then dup here @ swap - swap ! ; immediate
+: bp>cfa 2 + ; 
 
 : for here @ ['] >r , ; immediate
-: next ['] r> , LITERAL , 1 , ['] - , ['] dup , ['] 0= , BRANCH0 , here @ - , ['] drop , ; immediate
+: next ['] r> , 
+    LITERAL , 1 , 
+    ['] - , ['] dup , 
+    ['] 0= , BRANCH0 , 
+    here @ - , 
+    ['] drop , ; immediate
 
 : begin here @ ; immediate
 : until BRANCH0 , here @ - , ; immediate
@@ -65,8 +85,6 @@
 : 1+ ( n -- n+1 ) 1 + ;
 : negate ( n -- -n ) 0 swap - ;
 : not 0= ;
-: nip ( a b -- b ) swap drop ;
-: tuck ( a b -- b a b ) swap over ;
 : pop ( a -- ) drop ;
 : 2dup ( a b -- a b a b ) over over ;
 : ?dup dup 0= if dup else then ;
@@ -81,12 +99,21 @@
 
 : type ( s -- ) ADDRESS_MASK and dup c@ dup rot + swap for dup i - 1+ c@ emit next drop BL emit ;
 
+: tell ( s l -- ) swap ADDRESS_MASK and swap for dup i - 1+ c@ emit next drop BL emit ;
+
 : .tmp tmp @ type ;
 : .pad pad @ type ;
-: ." s" .tmp ;
+: ." state @
+    if
+        STRLIT , 
+        s" drop s-create ,
+        ['] type ,
+    else
+        s" drop type
+    then ; immediate
 
 \ Implementation of word
-: .word ( bp -- bp ) dup 1+ @ type space @ ;             \ prints a word name, given the preceding back pointer
+: .word ( bp -- bp ) dup dup '[' emit . 1+ @ type ']' emit space @ ;             \ prints a word name, given the preceding back pointer
 : words ( -- ) here @ 1- @ begin .word dup not until ;   \ loops through the words in the dictionary
 
 : dbg-debug 3 dbg ;

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -34,11 +34,23 @@
 
 \ Untested implementation of recursion support
 : recurse ( -- ) \ Simply compiles the cfa of the word being defined
-    last @ , ; immediate
+    last @ 1 + , ; immediate \ last points to the latest nfa, so increment
 
 : .tmp tmp @ type ;
 : .pad pad @ type ;
 : ." s" .tmp ;
+: ' (') @ ;
+: ['] LITERAL , ' , ; immediate                     \ compiles a word's cfa into a definition as a literal
+: >nfa 1 - ;                                        \ converts an cfa to an nfa
+: >cfa 1 + ;                                        \ converts an nfa to a cfa
+
+\ if else then WIP
+\ : iff BRANCH0 , here @ >r 0 , ; immediate
+\ : eelse ['] r> , here @ - , BRANCH , here @ >r 0 , ; immediate
+\ : tthen r> 
+
+: for here @ ['] >r , ; immediate
+: next ['] r> , LITERAL , 1 , ['] - , ['] dup , ['] 0= , BRANCH0 , here @ - , ['] drop , ; immediate
 
 : 1- ( n -- n-1 ) 1 - ;
 : 1+ ( n -- n+1 ) 1 + ;
@@ -67,8 +79,8 @@
 : +! ( n addr -- ) dup @ rot + swap ! ;
 : ? ( addr -- ) @ . ;
 
-s" src/regression.fs" 
-: run-regression clear tmp @ include-file ;
+\ s" src/regression.fs" 
+\ : run-regression include ;
 
 
 ( Application functions )

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -33,11 +33,8 @@
 ( inner interpreter op codes, used by control structures )
 
 \ Untested implementation of recursion support
-: recurse ( -- ) \ Put a return address on the stack, then branch back to the cfa of the word
-    LITERAL , here 5 + ,
-    ' >r @ ,
-    BRANCH ,
-    last @ here @ - 1 - , ; immediate
+: recurse ( -- ) \ Simply compiles the cfa of the word being defined
+    last @ , ; immediate
 
 : .tmp tmp @ type ;
 : .pad pad @ type ;

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -53,6 +53,7 @@
 
 : begin here @ ; immediate
 : until BRANCH0 , here @ - , ; immediate
+: again BRANCH , here @ - , ; immediate
 : while BRANCH0 , here @ 0 , ;  immediate
 : repeat BRANCH , swap here @ - , dup here @ swap - swap ! ; immediate
 
@@ -75,7 +76,7 @@
 : spaces ( n -- ) 1- for space next ;
 
 \ Implementation of word
-: .word ( bp -- bp ) dup 1+ @ type space @ ;                \ prints a word name, given the preceding back pointer
+: .word ( bp -- bp ) dup 1+ @ type space @ ;             \ prints a word name, given the preceding back pointer
 : words ( -- ) here @ 1- @ begin .word dup not until ;   \ loops through the words in the dictionary
 
 : dbg-debug 3 dbg ;

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -44,17 +44,17 @@
 : >nfa 1 - ;                                        \ converts an cfa to an nfa
 : >cfa 1 + ;                                        \ converts an nfa to a cfa
 
-\ if else then WIP
-\ : iff BRANCH0 , here @ >r 0 , ; immediate
-\ : eelse ['] r> , here @ - , BRANCH , here @ >r 0 , ; immediate
-\ : tthen r> 
+ : if BRANCH0 , here @  0 , ; immediate
+ : else BRANCH , here @ 0 , swap dup here @ swap - swap ! ; immediate
+ : then dup here @ swap - swap ! ; immediate
 
 : for here @ ['] >r , ; immediate
 : next ['] r> , LITERAL , 1 , ['] - , ['] dup , ['] 0= , BRANCH0 , here @ - , ['] drop , ; immediate
 
 : 1- ( n -- n-1 ) 1 - ;
 : 1+ ( n -- n+1 ) 1 + ;
-: negate ( n -- -n ) if 0 else -1 then ;
+: negate ( n -- -n ) 0 swap - ;
+: not 0= ;
 : nip ( a b -- b ) swap drop ;
 : tuck ( a b -- b a b ) swap over ;
 : pop ( a -- ) drop ;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -45,7 +45,7 @@ pub struct TF {
     pub data: [i64; DATA_SIZE],
     pub strings: [char; STRING_SIZE], // storage for strings
     pub builtins: Vec<BuiltInFn>,     // the dictionary of builtins
-    pub return_stack: Vec<i64>,       // for do loops etc.
+    //pub return_stack: Vec<i64>,       // for do loops etc.
     pub here_ptr: usize,
     pub stack_ptr: usize,  // top of the linear space stack
     pub return_ptr: usize, // top of the return stack
@@ -86,7 +86,7 @@ impl TF {
                 data: [0; DATA_SIZE],
                 strings: [' '; STRING_SIZE],
                 builtins: Vec::new(),
-                return_stack: Vec::new(),
+                //return_stack: Vec::new(),
                 here_ptr: WORD_START,
                 stack_ptr: STACK_START,
                 return_ptr: RET_START,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,6 +3,7 @@
 use crate::internals::builtin::BuiltInFn;
 use crate::messages::Msg;
 use crate::reader::Reader;
+use std::time::Instant;
 
 // DATA AREA constants
 pub const DATA_SIZE: usize = 10000;
@@ -68,6 +69,7 @@ pub struct TF {
     pub reader: Vec<Reader>, // allows for nested file processing
     pub show_stack: bool,    // show the stack at the completion of a line of interaction
     pub step_mode: bool,
+    pub timer: Instant, // for timing things
 }
 
 #[derive(Debug)]
@@ -110,6 +112,7 @@ impl TF {
                 reader: Vec::new(),
                 show_stack: true,
                 step_mode: false,
+                timer: Instant::now(),
             };
             interpreter.reader.push(reader);
             interpreter

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -59,13 +59,13 @@ pub struct TF {
     pub last_ptr: usize,   // points to name of top word
     pub hld_ptr: usize,    // for numeric string work
     pub file_mode: FileMode,
-    pub compile_ptr: usize, // true if compiling a word
-    pub pc_ptr: usize,      // program counter
-    pub abort_ptr: usize,   // true if abort has been called
-    pub tib_ptr: usize,     // TIB
+    pub state_ptr: usize, // true if compiling a word
+    pub pc_ptr: usize,    // program counter
+    pub abort_ptr: usize, // true if abort has been called
+    pub tib_ptr: usize,   // TIB
     pub tib_size_ptr: usize,
     pub tib_in_ptr: usize,
-    exit_flag: bool, // set when the "bye" word is executed.
+    pub exit_flag: bool, // set when the "bye" word is executed.
     pub msg: Msg,
     pub reader: Vec<Reader>, // allows for nested file processing
     pub show_stack: bool,    // show the stack at the completion of a line of interaction
@@ -101,7 +101,7 @@ impl TF {
                 last_ptr: 0,
                 hld_ptr: 0,
                 file_mode: FileMode::Unset,
-                compile_ptr: 0,
+                state_ptr: 0,
                 pc_ptr: 0,
                 abort_ptr: 0,
                 tib_ptr: 0,
@@ -124,7 +124,7 @@ impl TF {
         self.u_insert_variables();
         //self.f_insert_builtins();
         self.add_builtins();
-        self.set_var(self.compile_ptr, FALSE);
+        self.set_var(self.state_ptr, FALSE);
         self.u_insert_code(); // allows forth code to be run prior to presenting a prompt.
     }
 
@@ -140,7 +140,7 @@ impl TF {
 
     /// get_compile_mode *** needs to work with 'EVAL contents
     pub fn get_compile_mode(&mut self) -> bool {
-        if self.get_var(self.compile_ptr) == FALSE {
+        if self.get_var(self.state_ptr) == FALSE {
             false
         } else {
             true
@@ -149,7 +149,7 @@ impl TF {
 
     /// get_compile_mode *** needs to work with 'EVAL contents
     pub fn set_compile_mode(&mut self, value: bool) {
-        self.set_var(self.compile_ptr, if value { -1 } else { 0 });
+        self.set_var(self.state_ptr, if value { -1 } else { 0 });
     }
 
     pub fn set_abort_flag(&mut self, v: bool) {
@@ -166,22 +166,6 @@ impl TF {
 
     pub fn set_program_counter(&mut self, val: usize) {
         self.set_var(self.pc_ptr, val as i64);
-    }
-    fn get_program_counter(&mut self) -> usize {
-        self.get_var(self.pc_ptr) as usize
-    }
-    fn increment_program_counter(&mut self, val: usize) {
-        let new = self.get_program_counter() + val;
-        self.set_var(self.pc_ptr, (new) as i64);
-    }
-    fn decrement_program_counter(&mut self, val: usize) {
-        let new = self.get_program_counter() - val;
-        self.set_var(self.pc_ptr, (new) as i64);
-    }
-
-    pub fn set_exit_flag(&mut self) {
-        // Method executed by "bye"
-        self.exit_flag = true;
     }
 
     pub fn should_exit(&self) -> bool {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -16,9 +16,10 @@ pub const RET_START: usize = DATA_SIZE - 1; // return stack counts downwards
 pub const WORD_START: usize = 0; // data area counts up from the bottom (builtins, words, variables etc.)
 
 // STRING AREA constants
-pub const TIB_START: usize = 0;
-pub const PAD_START: usize = TIB_START + BUF_SIZE;
-pub const STR_START: usize = PAD_START + BUF_SIZE;
+pub const TIB_START: usize = 0; // Text input buffer, used by readers
+pub const PAD_START: usize = TIB_START + BUF_SIZE; // Scratchpad buffer, used by PARSE and friends
+pub const TMP_START: usize = PAD_START + BUF_SIZE; // Temporary buffer, used for string input
+pub const STR_START: usize = TMP_START + BUF_SIZE; // Free space for additional strings
 
 // GENERAL constants
 pub const TRUE: i64 = -1; // forth convention for true and false
@@ -52,7 +53,8 @@ pub struct TF {
     pub context_ptr: usize,
     pub eval_ptr: usize, // used to turn compile mode on and off
     pub base_ptr: usize,
-    pub pad_ptr: usize,    // the current s".."" string
+    pub pad_ptr: usize,    // string buffer for parser
+    pub tmp_ptr: usize,    // temporary string buffer
     pub string_ptr: usize, // points to the beginning of free string space
     pub last_ptr: usize,   // points to name of top word
     pub hld_ptr: usize,    // for numeric string work
@@ -95,6 +97,7 @@ impl TF {
                 eval_ptr: 0,
                 base_ptr: 0,
                 pad_ptr: 0,
+                tmp_ptr: 0,
                 last_ptr: 0,
                 hld_ptr: 0,
                 file_mode: FileMode::Unset,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,10 +1,8 @@
 //The tForth interpreter struct and implementation
 
 use crate::internals::builtin::BuiltInFn;
-// use crate::internals::compiler::*;
 use crate::messages::Msg;
 use crate::reader::Reader;
-//use crate::tokenizer::{ForthToken, Tokenizer};
 
 // DATA AREA constants
 pub const DATA_SIZE: usize = 10000;
@@ -122,7 +120,6 @@ impl TF {
 
     pub fn cold_start(&mut self) {
         self.u_insert_variables();
-        //self.f_insert_builtins();
         self.add_builtins();
         self.set_var(self.state_ptr, FALSE);
         self.u_insert_code(); // allows forth code to be run prior to presenting a prompt.

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -250,11 +250,12 @@ impl TF {
             TF::f_hide_stack,
             "hide-stack ( -- ) Turn off automatic stack display",
         );
-        self.u_add_builtin(
-            ".s\"",
-            TF::f_dot_s_quote,
-            ".s\" Print the contents of the pad",
-        );
+        /*         self.u_add_builtin(
+                   ".s\"",
+                   TF::f_dot_s_quote,
+                   ".s\" Print the contents of the pad",
+               );
+        */
         self.u_add_builtin(
             "emit",
             TF::f_emit,
@@ -524,11 +525,11 @@ impl TF {
             TF::f_s_create,
             "s-create ( s1 -- s2 ) Copy a string to the head of free space and return its address",
         );
-        self.u_add_builtin(
+        /*         self.u_add_builtin(
             ".s\"",
             TF::f_dot_s_quote,
             ".s\" ( s -- ) Print a string from a string address",
-        );
+        ); */
         /*         self.u_add_builtin(
             "s-parse",
             TF::f_s_parse,

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -406,9 +406,9 @@ impl TF {
         Return it's address or FALSE if not found",
         );
         self.u_add_builtin(
-            "'",
-            TF::f_tick,
-            "' <name> (tick) ( -- cfa ) searches the dictionary for a (postfix) word",
+            "(')",
+            TF::f_tick_p,
+            "(') <name> ( -- a ) searches the dictionary for a (postfix) word, returning its address",
         );
         self.u_add_builtin(
             "query",
@@ -493,14 +493,14 @@ impl TF {
         self.f_immediate();
         self.u_add_builtin("then", TF::f_then, "then ( -- ) closes if expression");
         self.f_immediate();
-        self.u_add_builtin("for", TF::f_for, "for ( n -- ) initiates iterative loop");
+        /*     self.u_add_builtin("for", TF::f_for, "for ( n -- ) initiates iterative loop");
         self.f_immediate();
         self.u_add_builtin(
             "next",
             TF::f_next,
             "next ( -- ) decrement loop counter, and branch back if > 0",
         );
-        self.f_immediate();
+        self.f_immediate(); */
         self.u_add_builtin(
             "s-create",
             TF::f_s_create,

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -420,12 +420,6 @@ impl TF {
             "accept ( b l1 -- b l2 ) Read up to l1 characters into the buffer at b.
         Return the pointer to the buffer and the actual number of characters read.",
         );
-        /*         self.u_add_builtin(
-                   "text",
-                   TF::f_text,
-                   "TEXT ( -- ) Get a space-delimited token from the TIB, place in PAD",
-               );
-        */
         self.u_add_builtin(
             "parse-to",
             TF::f_parse_to,
@@ -439,27 +433,13 @@ impl TF {
         self.u_add_builtin(
             "s\"",
             TF::f_s_quote,
-            "s\" Place the following string in the PAD",
+            "s\" Place the following string in the TMP string buffer",
         );
         self.u_add_builtin(
             "type",
             TF::f_type,
             "type: print a string using pointer on stack",
         );
-        /*         self.u_add_builtin(
-                   "\\",
-                   TF::f_backslash,
-                   "\\ ( -- ) Comment: ignore the remainder of the line",
-               );
-
-        self.f_immediate();
-        self.u_add_builtin(
-            "(",
-            TF::f_l_paren,
-            "( <text> ) Inline comment - text inside the parens is ignored",
-        );
-        self.f_immediate();
-        */
         self.u_add_builtin(
             "variable",
             TF::f_variable,

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -487,5 +487,15 @@ impl TF {
             TF::f_s_copy,
             "s-copy ( source dest -- ) Copy a counted string from source to dest",
         );
+        self.u_add_builtin(
+            "c@",
+            TF::f_c_get,
+            "c@ ( s -- c ) Copy a character from string address s to the stack",
+        );
+        self.u_add_builtin(
+            "c!",
+            TF::f_c_store,
+            "c! ( c s -- ) Copy character c to string address s",
+        );
     }
 }

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -484,24 +484,6 @@ impl TF {
         );
         self.u_add_builtin("see", TF::f_see, "see <name> decompiles and prints a word");
         self.u_add_builtin(
-            "if",
-            TF::f_if,
-            "if ( b -- ) if b is true, continue; otherwise branch to else or then",
-        );
-        self.f_immediate();
-        self.u_add_builtin("else", TF::f_else, "else ( -- ) branch to then");
-        self.f_immediate();
-        self.u_add_builtin("then", TF::f_then, "then ( -- ) closes if expression");
-        self.f_immediate();
-        /*     self.u_add_builtin("for", TF::f_for, "for ( n -- ) initiates iterative loop");
-        self.f_immediate();
-        self.u_add_builtin(
-            "next",
-            TF::f_next,
-            "next ( -- ) decrement loop counter, and branch back if > 0",
-        );
-        self.f_immediate(); */
-        self.u_add_builtin(
             "s-create",
             TF::f_s_create,
             "s-create ( s1 -- s2 ) Copy a string to the head of free space and return its address",

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -251,12 +251,6 @@ impl TF {
             TF::f_hide_stack,
             "hide-stack ( -- ) Turn off automatic stack display",
         );
-        /*         self.u_add_builtin(
-                   ".s\"",
-                   TF::f_dot_s_quote,
-                   ".s\" Print the contents of the pad",
-               );
-        */
         self.u_add_builtin(
             "emit",
             TF::f_emit,
@@ -270,11 +264,6 @@ impl TF {
         self.u_add_builtin("clear", TF::f_clear, "clear: resets the stack to empty");
         self.u_add_builtin(":", TF::f_colon, ": starts a new definition");
         self.u_add_builtin("bye", TF::f_bye, "bye: exits to the operating system");
-        self.u_add_builtin(
-            "words",
-            TF::f_words,
-            "words: Lists all defined words to the terminal",
-        );
         self.u_add_builtin(
             "dup",
             TF::f_dup,
@@ -318,11 +307,6 @@ impl TF {
             "abort",
             TF::f_abort,
             "abort ( -- ) Ends execution of the current word and clears the stack",
-        );
-        self.u_add_builtin(
-            "see-all",
-            TF::f_see_all,
-            "see-all: Prints the definitions of known words",
         );
         self.u_add_builtin(
             "depth",

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -467,16 +467,6 @@ impl TF {
             TF::f_s_create,
             "s-create ( s1 -- s2 ) Copy a string to the head of free space and return its address",
         );
-        /*         self.u_add_builtin(
-            ".s\"",
-            TF::f_dot_s_quote,
-            ".s\" ( s -- ) Print a string from a string address",
-        ); */
-        /*         self.u_add_builtin(
-            "s-parse",
-            TF::f_s_parse,
-            "s-parse ( c -- ) Read a delimited string into TMP",
-        ); */
         self.u_add_builtin(
             "s-copy",
             TF::f_s_copy,

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -354,9 +354,6 @@ impl TF {
             TF::f_immediate,
             "immediate sets the immediate flag on the most recently defined word",
         );
-        self.u_add_builtin("[", TF::f_lbracket, "[ ( -- ) Exit compile mode");
-        self.f_immediate();
-        self.u_add_builtin("]", TF::f_rbracket, "] ( -- ) Enter compile mode");
         self.u_add_builtin(
             "quit",
             TF::f_quit,
@@ -415,11 +412,12 @@ impl TF {
             TF::f_parse_p,
             "(parse) - b u c -- b u delta ) return the location of a delimited token in string space",
         );
-        self.u_add_builtin(
-            "s\"",
-            TF::f_s_quote,
-            "s\" Place the following string in the TMP string buffer",
-        );
+        /*        self.u_add_builtin(
+                   "s\"",
+                   TF::f_s_quote,
+                   "s\" Place the following string in the TMP string buffer",
+               );
+        */
         self.u_add_builtin(
             "variable",
             TF::f_variable,

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -511,9 +511,9 @@ impl TF {
         self.f_immediate();
         self.u_add_builtin("else", TF::f_else, "else ( -- ) branch to then");
         self.f_immediate();
-        self.u_add_builtin("then", TF::f_then, "then ( -- ) continue");
+        self.u_add_builtin("then", TF::f_then, "then ( -- ) closes if expression");
         self.f_immediate();
-        self.u_add_builtin("for", TF::f_for, "for ( n -- ) continue");
+        self.u_add_builtin("for", TF::f_for, "for ( n -- ) initiates iterative loop");
         self.f_immediate();
         self.u_add_builtin(
             "next",
@@ -539,7 +539,7 @@ impl TF {
         self.u_add_builtin(
             "s-copy",
             TF::f_s_copy,
-            "s-pcopy ( source dest -- ) Copy a counted string from source to dest",
+            "s-copy ( source dest -- ) Copy a counted string from source to dest",
         );
     }
 }

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -141,53 +141,53 @@ impl TF {
         self.u_add_builtin(
             "_builtin",
             TF::i_builtin,
-            "_builtin ( opcode -- ) executes the builtin on the stack",
+            "_builtin  opcode -- executes the builtin on the stack",
         );
         self.u_add_builtin(
             "_variable",
             TF::i_variable,
-            "variable ( opcode -- ) loads a variable's address on the stack",
+            "variable  opcode -- loads a variable's address on the stack",
         );
         self.u_add_builtin(
             "_constant",
             TF::i_constant,
-            "_constant ( opcode -- ) loads a constant's value on the stack",
+            "_constant  opcode -- loads a constant's value on the stack",
         );
         self.u_add_builtin(
             "_literal",
             TF::i_literal,
-            "_literal ( opcode -- ) loads a number on the stack",
+            "_literal  opcode -- loads a number on the stack",
         );
         self.u_add_builtin(
             "_stringlit",
             TF::i_strlit,
-            "_stringlit ( opcode -- ) loads a string pointer on the stack",
+            "_stringlit  opcode -- loads a string pointer on the stack",
         );
         self.u_add_builtin(
             "_definition",
             TF::i_builtin,
-            "_definition ( opcode -- ) executes a colon definition",
+            "_definition  opcode -- executes a colon definition",
         );
         self.u_add_builtin(
             "_branch",
             TF::i_branch,
-            "_branch ( opcode -- ) executes an unconditional branch",
+            "_branch  opcode -- executes an unconditional branch",
         );
         self.u_add_builtin(
             "_branch0",
             TF::i_branch0,
-            "_branch0 ( opcode --  executes a branch if zero",
+            "_branch0 opcode -- executes a branch if zero",
         );
         self.u_add_builtin("_abort", TF::f_abort, "abort ( opcode -- ) calls ABORT");
         self.u_add_builtin(
-            "_exit",
+            "exit",
             TF::i_exit,
-            "_exit ( opcode -- ) returns from the current definition",
+            "exit ( -- ) returns from the current definition",
         );
         self.u_add_builtin(
             "_next",
             TF::i_next,
-            "_next ( opcode -- ) end of word - continue to the next one",
+            "_next opcode -- end of word - continue to the next one",
         );
         // Start of normal functions
         self.u_add_builtin(

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -480,5 +480,16 @@ impl TF {
             TF::f_c_store,
             "c! ( c s -- ) Copy character c to string address s",
         );
+        self.u_add_builtin("now", TF::f_now, "c! ( -- ) Start a timers");
+        self.u_add_builtin(
+            "micros",
+            TF::f_micros,
+            "elapsed ( -- n ) Microseconds since NOW was called",
+        );
+        self.u_add_builtin(
+            "millis",
+            TF::f_millis,
+            "millis ( -- n ) Milliseconds since NOW was called",
+        );
     }
 }

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -330,7 +330,7 @@ impl TF {
         self.u_add_builtin(
             "key",
             TF::f_key,
-            "key ( -- c ) Get a character from the terminal",
+            "key ( -- c | 0 ) get a character and push on the stack, or zero if none available",
         );
         self.u_add_builtin("r/w", TF::f_r_w, "");
         self.u_add_builtin("r/o", TF::f_r_o, "");

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -421,11 +421,6 @@ impl TF {
             "s\" Place the following string in the TMP string buffer",
         );
         self.u_add_builtin(
-            "type",
-            TF::f_type,
-            "type: print a string using pointer on stack",
-        );
-        self.u_add_builtin(
             "variable",
             TF::f_variable,
             "variable <name> creates a new variable in the dictionary",

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -71,8 +71,9 @@ impl TF {
         self.data[self.tib_in_ptr] = TIB_START as i64 + 1;
         self.hld_ptr = self.u_make_variable("hld");
         self.last_ptr = self.u_make_variable("last"); // points to nfa of new definition
-        self.compile_ptr = self.u_make_variable("'eval");
+        self.state_ptr = self.u_make_variable("'eval");
         self.abort_ptr = self.u_make_variable("abort?");
+        self.state_ptr = self.u_make_variable("state");
         self.data[self.abort_ptr] = FALSE;
     }
 
@@ -407,7 +408,7 @@ impl TF {
         self.u_add_builtin(
             "'",
             TF::f_tick,
-            "' (tick): searches the dictionary for a (postfix) word",
+            "' <name> (tick) ( -- cfa ) searches the dictionary for a (postfix) word",
         );
         self.u_add_builtin(
             "query",

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -234,11 +234,11 @@ impl TF {
             TF::f_0less,
             "( j k -- j/k ) If j < 0 push true else false",
         );
-        self.u_add_builtin(
+        /*         self.u_add_builtin(
             ".s",
             TF::f_dot_s,
             ".s ( -- ) Print the contents of the calculation stack",
-        );
+        ); */
         self.u_add_builtin("cr", TF::f_cr, "cr ( -- ) Print a newline");
         self.u_add_builtin(
             "show-stack",
@@ -419,20 +419,20 @@ impl TF {
             "accept ( b l1 -- b l2 ) Read up to l1 characters into the buffer at b.
         Return the pointer to the buffer and the actual number of characters read.",
         );
+        /*         self.u_add_builtin(
+                   "text",
+                   TF::f_text,
+                   "TEXT ( -- ) Get a space-delimited token from the TIB, place in PAD",
+               );
+        */
         self.u_add_builtin(
-            "text",
-            TF::f_text,
-            "TEXT ( -- ) Get a space-delimited token from the TIB, place in PAD",
-        );
-        self.u_add_builtin(
-            "parse",
-            TF::f_text,
-            "PARSE ( c -- b u ) Get a c-delimited token from TIB, 
-        and return counted string in PAD",
+            "parse-to",
+            TF::f_parse_to,
+            "parse-to ( b c -- b u ) Get a c-delimited token from TIB, and return counted string in string buffer b",
         );
         self.u_add_builtin(
             "(parse)",
-            TF::f_text,
+            TF::f_parse_p,
             "(parse) - b u c -- b u delta ) return the location of a delimited token in string space",
         );
         self.u_add_builtin(
@@ -445,22 +445,20 @@ impl TF {
             TF::f_type,
             "type: print a string using pointer on stack",
         );
-        self.u_add_builtin(
-            "recurse",
-            TF::f_recurse,
-            "recurse ( -- ) implements recursion inside a word definition",
-        );
-        self.u_add_builtin(
-            "\\",
-            TF::f_backslash,
-            "\\ ( -- ) Comment: ignore the remainder of the line",
-        );
+        /*         self.u_add_builtin(
+                   "\\",
+                   TF::f_backslash,
+                   "\\ ( -- ) Comment: ignore the remainder of the line",
+               );
+
+        self.f_immediate();
         self.u_add_builtin(
             "(",
             TF::f_l_paren,
             "( <text> ) Inline comment - text inside the parens is ignored",
         );
         self.f_immediate();
+        */
         self.u_add_builtin(
             "variable",
             TF::f_variable,
@@ -531,11 +529,11 @@ impl TF {
             TF::f_dot_s_quote,
             ".s\" ( s -- ) Print a string from a string address",
         );
-        self.u_add_builtin(
+        /*         self.u_add_builtin(
             "s-parse",
             TF::f_s_parse,
             "s-parse ( c -- ) Read a delimited string into TMP",
-        );
+        ); */
         self.u_add_builtin(
             "s-copy",
             TF::f_s_copy,

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -58,16 +58,6 @@ impl TF {
         }
     }
 
-    /// [  Install $INTERPRET in 'EVAL
-    pub fn f_lbracket(&mut self) {
-        self.set_compile_mode(false);
-    }
-
-    /// ]  Install $COMPILE in 'EVAL   
-    pub fn f_rbracket(&mut self) {
-        self.set_compile_mode(true);
-    }
-
     pub fn f_abort(&mut self) {
         // empty the stack, reset any pending operations, and return to the prompt
         self.msg
@@ -319,7 +309,7 @@ impl TF {
                 let start = in_p as usize;
                 let end = start + buf_len as usize;
                 let mut i = start as usize;
-                let mut j = i;
+                let mut j;
                 while self.strings[i] == delim && i < end {
                     i += 1;
                 }
@@ -494,7 +484,11 @@ impl TF {
                                     print!("{} ", self.data[index as usize + 1]);
                                     index += 1;
                                 }
-                                STRLIT => {} // print string contents
+                                STRLIT => {
+                                    let s_addr = self.data[index as usize + 1] as usize;
+                                    print!("\" {}\" ", self.u_get_string(s_addr));
+                                    index += 1;
+                                }
                                 BRANCH => {
                                     print!("branch:{} ", self.data[index as usize + 1]);
                                     index += 1;

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -508,24 +508,11 @@ impl TF {
                         loop {
                             let xt = self.data[index];
                             match xt {
-                                BUILTIN => {
-                                    let opcode =
-                                        self.data[self.data[index as usize + 1] as usize] as usize;
-                                    let name = &self.builtins[opcode].name;
-                                    print!("{name} ");
-                                    index += 1; // we consumed an extra cell
-                                }
-                                VARIABLE | CONSTANT => {
-                                    let name =
-                                        self.u_get_string(self.data[xt as usize - 1] as usize);
-                                    print!("{} ", name);
-                                }
                                 LITERAL => {
                                     print!("{} ", self.data[index as usize + 1]);
                                     index += 1;
                                 }
-                                STRLIT => {}                 // print string contents
-                                DEFINITION => print!("???"), // Can't have a definition inside a definition
+                                STRLIT => {} // print string contents
                                 BRANCH => {
                                     print!("branch:{} ", self.data[index as usize + 1]);
                                     index += 1;
@@ -544,16 +531,12 @@ impl TF {
                                     }
                                     break;
                                 }
-                                NEXT => {
-                                    println!(";");
-                                    break;
-                                }
                                 _ => {
-                                    // it's a colon definition or a builtin
+                                    // it's a definition or a builtin
                                     let mut cfa = self.data[index] as usize;
                                     let mut mask = cfa & BUILTIN_MASK;
                                     if mask == 0 {
-                                        let word = self.data[self.data[cfa] as usize - 1]; // nfa address
+                                        let word = self.data[self.data[index] as usize - 1]; // nfa address
                                         let name = self.u_get_string(word as usize);
                                         print!("{name} ");
                                     } else {

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -117,7 +117,7 @@ impl TF {
                 NEXT => self.i_next(),
                 _ => {
                     pop!(self);
-                    let cfa = self.data[xt as usize] as usize & !BUILTIN_MASK;
+                    let cfa = self.data[xt as usize] as usize & ADDRESS_MASK;
                     push!(self, cfa as i64);
                     self.i_builtin();
                 }
@@ -249,10 +249,9 @@ impl TF {
     /// leaves n and flag on the stack: true if number is ok.
     pub fn f_number_q(&mut self) {
         let buf_addr = pop!(self);
-        let mut result = 0;
         let numtext = self.u_get_string(buf_addr as usize);
         if u_is_integer(&numtext.as_str()) {
-            result = numtext.parse().unwrap();
+            let result = numtext.parse().unwrap();
             push!(self, result);
             push!(self, TRUE);
         } else {
@@ -340,7 +339,7 @@ impl TF {
         }
     }
 
-    /// PARSE ( b d -- b u ) Get a d-delimited token from TIB, and return counted string in string buffer at b
+    /// PARSE-TO ( b d -- b u ) Get a d-delimited token from TIB, and return counted string in string buffer at b
     /// need to check if TIB is empty
     /// if delimiter = 1, get the rest of the TIB
     /// Update >IN as required, and set #TIB to zero if the line has been consumed

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -285,7 +285,7 @@ impl TF {
         }
     }
 
-    /// ' (TICK) <name> ( -- a | FALSE ) Searches for a word, places cfa on stack if found; otherwise FALSE
+    /// ' (TICK) <name> ( -- cfa | FALSE ) Searches for a word, places cfa on stack if found; otherwise FALSE
     /// Looks for a (postfix) word in the dictionary
     /// places it's execution token / address on the stack
     /// Pushes 0 if not found
@@ -303,7 +303,7 @@ impl TF {
             self.f_type(); // a warning message
             push!(self, FALSE);
         } else {
-            // we found it, so leave the cfa on the stack
+            self.f_get(); // convert it to a cfa
         }
     }
 

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -433,7 +433,7 @@ impl TF {
         let length = self.strings[self.data[self.pad_ptr] as usize] as u8 as i64;
         push!(self, length);
         push!(self, self.data[self.string_ptr]);
-        self.f_pack_d(); // make a new string with the name from PAD
+        self.f_smove(); // make a new string with the name from PAD
         self.data[self.data[self.here_ptr] as usize] = pop!(self); // the string header
         self.data[self.string_ptr] += length + 1; // update the free string pointer
         self.data[self.last_ptr] = self.data[self.here_ptr];
@@ -467,11 +467,11 @@ impl TF {
         }
     }
 
-    /// string <name> ( s -- ) Creates and initializez a new string variable in the dictionary
+    /// string <name> ( s -- ) Creates and initializez a new string from the PAD
     pub fn f_string(&mut self) {}
 
     /// f_pack_d ( source len dest -- dest ) builds a new counted string from an existing counted string.
-    pub fn f_pack_d(&mut self) {
+    pub fn f_smove(&mut self) {
         let dest = pop!(self) as usize;
         let length = pop!(self) as usize;
         let source = pop!(self) as usize;

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -397,7 +397,7 @@ impl TF {
         self.set_compile_mode(false);
     }
 
-    /// f_create makes a new dictionary entry, using a postfix name
+    /// CREATE <name> ( -- ) makes a new dictionary entry, using a postfix name
     /// References HERE, and assumes back pointer is in place already
     pub fn f_create(&mut self) {
         push!(self, self.data[self.pad_ptr]);

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -300,7 +300,7 @@ impl TF {
             let mut msg = self.u_get_string(self.data[self.pad_ptr] as usize);
             msg = format!("Word not found: {} ", msg);
             self.u_set_string(self.data[self.pad_ptr] as usize, &msg);
-            self.f_type(); // a warning message
+            // self.f_type(); // a warning message *** replace with a call to TELL
             push!(self, FALSE);
         }
     }

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -285,11 +285,11 @@ impl TF {
         }
     }
 
-    /// ' (TICK) <name> ( -- cfa | FALSE ) Searches for a word, places cfa on stack if found; otherwise FALSE
+    /// (') (TICK) <name> ( -- a | FALSE ) Searches for a word, places cfa on stack if found; otherwise FALSE
     /// Looks for a (postfix) word in the dictionary
     /// places it's execution token / address on the stack
     /// Pushes 0 if not found
-    pub fn f_tick(&mut self) {
+    pub fn f_tick_p(&mut self) {
         push!(self, self.data[self.pad_ptr]);
         push!(self, ' ' as i64);
         self.f_parse_to(); // ( -- b u )
@@ -302,8 +302,6 @@ impl TF {
             self.u_set_string(self.data[self.pad_ptr] as usize, &msg);
             self.f_type(); // a warning message
             push!(self, FALSE);
-        } else {
-            self.f_get(); // convert it to a cfa
         }
     }
 
@@ -341,28 +339,6 @@ impl TF {
             }
         }
     }
-
-    /*    /// TEXT ( -- b u ) Get a space-delimited token from the TIB, place in PAD
-       pub fn f_text(&mut self) {
-           push!(self, ' ' as u8 as i64);
-           self.f_parse();
-       }
-    */
-    /*  /// \ (backslash)  <text> \n Inline comment: ignores the remainder of the line
-    pub fn f_backslash(&mut self) {
-        push!(self, 1 as u8 as i64);
-        self.f_parse();
-        pop!(self); // throw away stack values left by f_parse
-        pop!(self);
-    } */
-
-    /// ( <text> ) Used for stack signature documentation. Ignores everything up to the right paren.
-    /*     pub fn f_l_paren(&mut self) {
-        push!(self, ')' as u8 as i64);
-        self.f_parse();
-        pop!(self); // throw away stack values left by f_parse, causing the text to be abandoned
-        pop!(self);
-    } */
 
     /// PARSE ( b d -- b u ) Get a d-delimited token from TIB, and return counted string in string buffer at b
     /// need to check if TIB is empty
@@ -475,9 +451,6 @@ impl TF {
         }
     }
 
-    /// string <name> ( s -- ) Creates and initializez a new string from the PAD
-    pub fn f_string(&mut self) {}
-
     /// f_pack_d ( source len dest -- dest ) builds a new counted string from an existing counted string.
     pub fn f_smove(&mut self) {
         let dest = pop!(self) as usize;
@@ -492,7 +465,7 @@ impl TF {
 
     /// see <name> ( -- ) prints the definition of a word
     pub fn f_see(&mut self) {
-        self.f_tick(); // finds the address of the word
+        self.f_tick_p(); // finds the address of the word
         let cfa = pop!(self);
         if cfa == FALSE {
             self.msg.warning("see", "Word not found", None::<bool>);

--- a/src/internals/console.rs
+++ b/src/internals/console.rs
@@ -133,10 +133,10 @@ impl TF {
         self.f_parse();
     }
 
-    pub fn f_dot_s_quote(&mut self) {
-        print!("{:?}", self.u_get_string(self.pad_ptr));
-    }
-
+    /*     pub fn f_dot_s_quote(&mut self) {
+           print!("{:?}", self.u_get_string(self.pad_ptr));
+       }
+    */
     /// TYPE - print a string, using the string address on the stack
     pub fn f_type(&mut self) {
         if stack_ok!(self, 1, "type") {

--- a/src/internals/console.rs
+++ b/src/internals/console.rs
@@ -1,5 +1,5 @@
 /// Input-output words
-use crate::engine::{FileMode, BUF_SIZE, FALSE, STACK_START, TF, TRUE};
+use crate::engine::{FileMode, ADDRESS_MASK, BUF_SIZE, FALSE, STACK_START, TF, TRUE};
 use crate::messages::Msg;
 use crate::reader::Reader;
 use std::cmp::min;
@@ -154,7 +154,7 @@ impl TF {
     /// type (s -- ) - print a string, using the string address on the stack
     pub fn f_type(&mut self) {
         if stack_ok!(self, 1, "type") {
-            let addr = pop!(self) as usize;
+            let addr = pop!(self) as usize & ADDRESS_MASK; // mask out any flags
             let text = self.u_get_string(addr);
             print!("{text}");
         }

--- a/src/internals/console.rs
+++ b/src/internals/console.rs
@@ -144,11 +144,12 @@ impl TF {
 
     /// s" ( -- ) get a string and place it in PAD
     pub fn f_s_quote(&mut self) {
+        push!(self, self.data[self.pad_ptr]);
         push!(self, '"' as i64);
-        self.f_parse();
+        self.f_parse_to();
     }
 
-    /// TYPE - print a string, using the string address on the stack
+    /// type (s -- ) - print a string, using the string address on the stack
     pub fn f_type(&mut self) {
         if stack_ok!(self, 1, "type") {
             let addr = pop!(self) as usize;

--- a/src/internals/console.rs
+++ b/src/internals/console.rs
@@ -142,11 +142,13 @@ impl TF {
         println!("");
     }
 
-    /// s" ( -- ) get a string and place it in PAD
+    /// s" ( -- ) get a string and place it in TMP
     pub fn f_s_quote(&mut self) {
-        push!(self, self.data[self.pad_ptr]);
+        push!(self, self.data[self.tmp_ptr]);
         push!(self, '"' as i64);
         self.f_parse_to();
+        pop!(self);
+        pop!(self);
     }
 
     /// type (s -- ) - print a string, using the string address on the stack

--- a/src/internals/console.rs
+++ b/src/internals/console.rs
@@ -1,5 +1,7 @@
 /// Input-output words
 use crate::engine::{FileMode, BUF_SIZE, STACK_START, TF};
+use crate::messages::Msg;
+use crate::reader::Reader;
 use std::cmp::min;
 use std::io::{self, Write};
 
@@ -35,48 +37,61 @@ macro_rules! push {
 }
 
 impl TF {
-    /// macros:
-    ///
-    /// pop! attempts to take one element off the computation stack,
-    ///      calling abort if underflow
-    ///
-
+    /// key ( -- c | 0 ) get a character and push on the stack, or zero if none available
     pub fn f_key(&mut self) {
-        // get a character and push on the stack
-        let c = self.reader.read_char();
-        match c {
-            Some(c) => {
-                push!(self, c as u8 as i64);
+        let reader = self.reader.last();
+        match reader {
+            Some(reader) => {
+                let c = reader.read_char();
+                match c {
+                    Some(c) => {
+                        push!(self, c as u8 as i64);
+                    }
+                    None => {
+                        push!(self, 0);
+                    }
+                }
             }
-            None => self
-                .msg
-                .error("KEY", "unable to get char from input stream", None::<bool>),
+            None => {}
         }
     }
 
-    /// ( b u -- b u ) ACCEPT
+    /// accept ( b u -- b u ) Read up to u characters, storing them at string address b and returning the actual length.
+    ///     If the read fails, we assume EOF, and pop the reader. Returned length will be 0.
     ///
-    /// Read up to u characters, storing them at string address b.
-    /// Return the start of the string, and the number of characters read.
-    /// Typically writes a counted string to the TIB, in which case,
-    /// it needs TIB_START and BUF_SIZE - 1 on the stack.
+    ///     Return the start of the string, and the number of characters read.
+    ///     Typically writes a counted string to the TIB, in which case,
+    ///     it needs TIB_START and BUF_SIZE - 1 on the stack.
     ///
     pub fn f_accept(&mut self) {
         if stack_ok!(self, 2, "accept") {
             let max_len = pop!(self);
             let dest = top!(self) as usize;
-            match self.reader.get_line() {
-                Some(line) => {
-                    let length = min(line.len() - 1, max_len as usize) as usize;
-                    let line_str = &line[..length];
-                    self.u_save_string(line_str, dest); // write a counted string
-                    push!(self, length as i64);
+            match self.reader.last_mut() {
+                Some(reader) => {
+                    let l = reader.get_line();
+                    match l {
+                        Some(line) => {
+                            let length = min(line.len() - 1, max_len as usize) as usize;
+                            let line_str = &line[..length];
+                            self.u_save_string(line_str, dest); // write a counted string
+                            push!(self, length as i64);
+                        }
+                        None => {
+                            // EOF - there are no more lines to read
+                            if self.reader.len() > 1 {
+                                // Reader 0 is stdin
+                                self.reader.pop();
+                                push!(self, 0);
+                            } else {
+                                panic!("Reader error - EOF in stdin");
+                            }
+                        }
+                    }
                 }
-                None => {
-                    self.msg
-                        .error("ACCEPT", "Unable to read from input", None::<bool>);
-                    self.f_abort();
-                }
+                None => self
+                    .msg
+                    .error("accept", "No input source available", None::<bool>),
             }
         }
     }
@@ -133,10 +148,6 @@ impl TF {
         self.f_parse();
     }
 
-    /*     pub fn f_dot_s_quote(&mut self) {
-           print!("{:?}", self.u_get_string(self.pad_ptr));
-       }
-    */
     /// TYPE - print a string, using the string address on the stack
     pub fn f_type(&mut self) {
         if stack_ok!(self, 1, "type") {
@@ -154,7 +165,37 @@ impl TF {
     pub fn f_r_o(&mut self) {
         self.file_mode = FileMode::ReadOnly;
     }
+
+    /// include-file (s -- ) Pushes a new reader, pointing to the file named at s, calling ABORT if unsuccessful
+    ///     The intent is that the standard loop will continue, now reading lines from the file
+    ///     At the end of the file, the reader will be popped off the stack.
+    ///     This allows for nested file reads.
+    ///
     pub fn f_include_file(&mut self) {
-        self.loaded();
+        if stack_ok!(self, 1, "include-file") {
+            let file_ptr = pop!(self) as usize;
+            let file_name = self.u_get_string(file_ptr);
+            let full_path = std::fs::canonicalize(file_name);
+            match full_path {
+                Ok(full_path) => {
+                    let reader = Reader::new(Some(&full_path), Msg::new());
+                    match reader {
+                        Some(reader) => {
+                            self.reader.push(reader);
+                        }
+                        None => {
+                            self.msg
+                                .error("loaded", "Failed to create new reader", None::<bool>);
+                            self.f_abort();
+                        }
+                    }
+                }
+                Err(error) => {
+                    self.msg
+                        .warning("include-file", error.to_string().as_str(), None::<bool>);
+                    self.f_abort();
+                }
+            }
+        }
     }
 }

--- a/src/internals/console.rs
+++ b/src/internals/console.rs
@@ -151,15 +151,6 @@ impl TF {
         pop!(self);
     }
 
-    /// type (s -- ) - print a string, using the string address on the stack
-    pub fn f_type(&mut self) {
-        if stack_ok!(self, 1, "type") {
-            let addr = pop!(self) as usize & ADDRESS_MASK; // mask out any flags
-            let text = self.u_get_string(addr);
-            print!("{text}");
-        }
-    }
-
     // file i/o
 
     pub fn f_r_w(&mut self) {

--- a/src/internals/debug.rs
+++ b/src/internals/debug.rs
@@ -39,18 +39,6 @@ impl TF {
         self.show_stack = false;
     }
 
-    /// WORDS ( -- ) Print a list of all defined words
-    ///              Includes definitions, builtins, variables and constants
-    pub fn f_words(&mut self) {
-        // walk the definition linked list and print each entry's name
-        println!("words - not implemented");
-    }
-
-    /// SEE-ALL ( -- ) Show decompiled versions of all the defined words
-    pub fn f_see_all(&mut self) {
-        println!("see-all - not implemented")
-    }
-
     /// DEPTH - print the number of items on the stack
     pub fn f_stack_depth(&mut self) {
         let depth = STACK_START - self.stack_ptr;

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -218,12 +218,6 @@ impl TF {
         push!(self, self.data[self.return_ptr + 1]);
     }
 
-    /// recurse ( -- ) Branches to the beginning of the current word.
-    ///     Branch distance needs to be calculated somehow... ***
-    pub fn f_recurse(&mut self) {
-        self.msg.error("recurse", "Not implemented", None::<bool>);
-    }
-
     /// s-copy (s-from s-to -- s-to )
     pub fn f_s_copy(&mut self) {
         if stack_ok!(self, 3, "s-copy") {
@@ -253,31 +247,32 @@ impl TF {
         }
     }
 
-    /// s-parse ( c -- ) Get a c-delimited string from TIB, and place in TMP
-    pub fn f_s_parse(&mut self) {
-        let delim = pop!(self);
-        // need to call (parse) to get the string directly from the TIB
-        push!(self, self.data[self.tib_ptr] + self.data[self.tib_in_ptr]);
-        push!(
-            self,
-            self.data[self.tib_size_ptr] - self.data[self.tib_in_ptr] + 1
-        );
-        push!(self, delim);
-        self.f_parse_p();
-        let delta = pop!(self);
-        let length = pop!(self);
-        let addr = pop!(self);
-        if length > 0 {
-            self.u_str_copy(
-                (addr + delta) as usize,
-                self.data[self.tmp_ptr] as usize,
-                length as usize,
-                false,
-            );
-        }
-    }
-
-    /// .s" (s -- ) Print a string using the string address on the stack
+    /* /// s-parse ( c -- ) Get a c-delimited string from TIB, and place in TMP
+       pub fn f_s_parse(&mut self) {
+           let delim = pop!(self);
+           // need to call (parse) to get the string directly from the TIB
+           push!(self, self.data[self.tib_ptr] + self.data[self.tib_in_ptr]);
+           push!(
+               self,
+               self.data[self.tib_size_ptr] - self.data[self.tib_in_ptr] + 1
+           );
+           push!(self, delim);
+           self.f_parse_p();
+           let delta = pop!(self);
+           let length = pop!(self);
+           let addr = pop!(self);
+           if length > 0 {
+               self.u_str_copy(
+                   (addr + delta) as usize,
+                   self.data[self.tmp_ptr] as usize,
+                   length as usize,
+                   false,
+               );
+           }
+           self.data[self.tib_in_ptr] += delta + length + 1;
+       }
+    */
+    /*     /// .s" (s -- ) Print a string using the string address on the stack
     pub fn f_dot_s_quote(&mut self) {
         if stack_ok!(self, 1, ".s") {
             let addr = pop!(self) as usize;
@@ -288,5 +283,5 @@ impl TF {
                 i += 1;
             }
         }
-    }
+    } */
 }

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -218,6 +218,22 @@ impl TF {
         push!(self, self.data[self.return_ptr + 1]);
     }
 
+    /// c@ - ( s -- c ) read a character from a string and place on the stack
+    pub fn f_c_get(&mut self) {
+        if stack_ok!(self, 1, "c@") {
+            let s_address = pop!(self) as usize;
+            push!(self, self.strings[s_address] as u8 as i64);
+        }
+    }
+
+    /// c! - ( c s -- ) read a character from a string and place on the stack
+    pub fn f_c_store(&mut self) {
+        if stack_ok!(self, 2, "c!") {
+            let s_address = pop!(self) as usize;
+            self.strings[s_address] = pop!(self) as u8 as char;
+        }
+    }
+
     /// s-copy (s-from s-to -- s-to )
     pub fn f_s_copy(&mut self) {
         if stack_ok!(self, 3, "s-copy") {

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -52,13 +52,6 @@ macro_rules! pop1_push1 {
         }
     };
 }
-/* macro_rules! pop1 {
-    ($self:ident, $word:expr, $code:expr) => {
-        if let Some(x) = $self.pop_one(&$word) {
-            $code(x);
-        }
-    };
-} */
 
 pub fn u_is_integer(s: &str) -> bool {
     s.parse::<i64>().is_ok()

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -1,6 +1,7 @@
 // General-purpose builtin words
 
 use crate::engine::{FALSE, STACK_START, TF, TRUE};
+use std::time::Instant;
 
 macro_rules! stack_ok {
     ($self:ident, $n: expr, $caller: expr) => {
@@ -260,5 +261,22 @@ impl TF {
             self.f_s_copy();
             self.data[self.string_ptr] += length as i64 + 1;
         }
+    }
+
+    /// f_now ( -- ) Start a timer
+    pub fn f_now(&mut self) {
+        self.timer = Instant::now();
+    }
+
+    /// micros ( -- n ) returns the number of microseconds since NOW was called
+    pub fn f_micros(&mut self) {
+        let duration = self.timer.elapsed();
+        push!(self, duration.as_micros() as i64);
+    }
+
+    /// millis ( -- n ) returns the number of milliseconds since NOW was called
+    pub fn f_millis(&mut self) {
+        let duration = self.timer.elapsed();
+        push!(self, duration.as_millis() as i64);
     }
 }

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -236,7 +236,7 @@ impl TF {
 
     /// s-copy (s-from s-to -- s-to )
     pub fn f_s_copy(&mut self) {
-        if stack_ok!(self, 3, "s-copy") {
+        if stack_ok!(self, 2, "s-copy") {
             let dest = pop!(self) as usize;
             let result_ptr = dest as i64;
             let source = pop!(self) as usize;
@@ -259,7 +259,6 @@ impl TF {
             push!(self, dest); // destination
             self.f_s_copy();
             self.data[self.string_ptr] += length as i64 + 1;
-            push!(self, dest);
         }
     }
 }

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -246,42 +246,4 @@ impl TF {
             push!(self, dest);
         }
     }
-
-    /* /// s-parse ( c -- ) Get a c-delimited string from TIB, and place in TMP
-       pub fn f_s_parse(&mut self) {
-           let delim = pop!(self);
-           // need to call (parse) to get the string directly from the TIB
-           push!(self, self.data[self.tib_ptr] + self.data[self.tib_in_ptr]);
-           push!(
-               self,
-               self.data[self.tib_size_ptr] - self.data[self.tib_in_ptr] + 1
-           );
-           push!(self, delim);
-           self.f_parse_p();
-           let delta = pop!(self);
-           let length = pop!(self);
-           let addr = pop!(self);
-           if length > 0 {
-               self.u_str_copy(
-                   (addr + delta) as usize,
-                   self.data[self.tmp_ptr] as usize,
-                   length as usize,
-                   false,
-               );
-           }
-           self.data[self.tib_in_ptr] += delta + length + 1;
-       }
-    */
-    /*     /// .s" (s -- ) Print a string using the string address on the stack
-    pub fn f_dot_s_quote(&mut self) {
-        if stack_ok!(self, 1, ".s") {
-            let addr = pop!(self) as usize;
-            let length = self.strings[addr] as usize + 1;
-            let mut i = 1;
-            while i <= length {
-                print!("{}", self.strings[addr + i]);
-                i += 1;
-            }
-        }
-    } */
 }

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -115,7 +115,7 @@ impl TF {
     }
 
     pub fn f_bye(&mut self) {
-        self.set_exit_flag();
+        self.exit_flag = true;
     }
 
     pub fn f_dup(&mut self) {

--- a/src/internals/inner.rs
+++ b/src/internals/inner.rs
@@ -254,14 +254,14 @@ impl TF {
     ///     Compile time: Compiles a >R and puts the pc on the compute stack.
     pub fn f_for(&mut self) {
         push!(self, self.data[self.here_ptr]); // so NEXT can calculate the BRANCH0
-        push!(self, 2305843009213694009); // *** hardwired address of >R !!! Not good !!!
+        push!(self, 2305843009213694007); // *** hardwired address of >R !!! Not good !!!
         self.f_comma();
     }
 
     /// f_next ( -- ) decrement loop counter; if <= 0, continue; otherwise push loop counter and branch back; IMMEDIATE
     ///     Compile time: Resolves the address on the stack, storing it into FOR's branch offset.
     pub fn f_next(&mut self) {
-        push!(self, 2305843009213694010); // R>
+        push!(self, 2305843009213694008); // R>
         self.f_comma();
         push!(self, LITERAL);
         self.f_comma();
@@ -269,7 +269,7 @@ impl TF {
         self.f_comma();
         push!(self, 2305843009213693965); // -
         self.f_comma();
-        push!(self, 2305843009213693987); // DUP
+        push!(self, 2305843009213693985); // DUP
         self.f_comma();
         push!(self, 2305843009213693974); // 0=
         self.f_comma();
@@ -279,7 +279,7 @@ impl TF {
         let there = pop!(self);
         push!(self, there - here);
         self.f_comma();
-        push!(self, 2305843009213693988);
+        push!(self, 2305843009213693986);
         self.f_comma();
     }
 }

--- a/src/internals/inner.rs
+++ b/src/internals/inner.rs
@@ -249,37 +249,4 @@ impl TF {
         // println!("Here:{} There:{}", here, there);
         self.data[there as usize] = here - there;
     }
-
-    /// f_for ( -- ) no execution semantics; IMMEDIATE
-    ///     Compile time: Compiles a >R and puts the pc on the compute stack.
-    pub fn f_for(&mut self) {
-        push!(self, self.data[self.here_ptr]); // so NEXT can calculate the BRANCH0
-        push!(self, 2305843009213694007); // *** hardwired address of >R !!! Not good !!!
-        self.f_comma();
-    }
-
-    /// f_next ( -- ) decrement loop counter; if <= 0, continue; otherwise push loop counter and branch back; IMMEDIATE
-    ///     Compile time: Resolves the address on the stack, storing it into FOR's branch offset.
-    pub fn f_next(&mut self) {
-        push!(self, 2305843009213694008); // R>
-        self.f_comma();
-        push!(self, LITERAL);
-        self.f_comma();
-        push!(self, 1);
-        self.f_comma();
-        push!(self, 2305843009213693965); // -
-        self.f_comma();
-        push!(self, 2305843009213693985); // DUP
-        self.f_comma();
-        push!(self, 2305843009213693974); // 0=
-        self.f_comma();
-        push!(self, BRANCH0);
-        self.f_comma();
-        let here = self.data[self.here_ptr];
-        let there = pop!(self);
-        push!(self, there - here);
-        self.f_comma();
-        push!(self, 2305843009213693986);
-        self.f_comma();
-    }
 }

--- a/src/internals/inner.rs
+++ b/src/internals/inner.rs
@@ -94,7 +94,6 @@ impl TF {
                 return; // we've completed the last exit or encountered an error
             }
             let code = self.data[pc];
-            // println!("{code}");
             match code {
                 BUILTIN => {
                     self.msg
@@ -122,9 +121,8 @@ impl TF {
                 }
                 STRLIT => {
                     pc += 1;
-                    push!(self, pc as i64); // the string address of the data
-                    self.f_r_from();
-                    pc = pop!(self) as usize;
+                    push!(self, self.data[pc] as i64); // the string address of the data
+                    pc += 1;
                 }
                 DEFINITION => {
                     pc += 1;

--- a/src/internals/inner.rs
+++ b/src/internals/inner.rs
@@ -209,44 +209,4 @@ impl TF {
     /// f_marker <name> ( -- ) sets a location for FORGET
     ///     It creates a definition called <name> that has the effect of resetting HERE and CONTEXT       
     pub fn f_marker(&mut self) {}
-
-    /// f_if ( b -- ) if the top of stack is TRUE, continue, otherwise branch to ELSE; IMMEDIATE
-    ///     Implemented by compiling BRANCH0 and an offset word, putting the offset word's address on the return stack.
-    pub fn f_if(&mut self) {
-        // need to know the current address where the definition is happening. ***
-        // We should be able to use HERE
-        push!(self, BRANCH0);
-        self.f_comma();
-        push!(self, self.data[self.here_ptr]);
-        self.f_to_r();
-        push!(self, 0); // placeholder
-        self.f_comma();
-    }
-
-    /// f_else ( -- ) branch to THEN; IMMEDIATE
-    ///     Compile time: Compiles BRANCH0 and an offset word, putting the offset word's address on the return stack.
-    ///     Resolves the address on the return stack and stores into IF's branch offset.
-    pub fn f_else(&mut self) {
-        let here = self.data[self.here_ptr];
-        self.f_r_from();
-        let there = pop!(self);
-        self.data[there as usize] = here - there + 2; // to skip the branch
-        push!(self, BRANCH);
-        self.f_comma();
-        push!(self, self.data[self.here_ptr]);
-        self.f_to_r();
-        push!(self, 0);
-        self.f_comma();
-    }
-
-    /// f_then ( -- ) no execution semantics; IMMEDIATE
-    ///     Compile time: Resolves the address on the stack, storing it into IF or ELSE's branch offset.
-    ///                   Compiles a BRANCH and pushes it's offset address on the return stack.
-    pub fn f_then(&mut self) {
-        let here = self.data[self.here_ptr];
-        self.f_r_from();
-        let there = pop!(self);
-        // println!("Here:{} There:{}", here, there);
-        self.data[there as usize] = here - there;
-    }
 }

--- a/src/internals/inner.rs
+++ b/src/internals/inner.rs
@@ -76,10 +76,9 @@ impl TF {
     ///    A program counter is used to step through the entries in the definition.
     ///    Each entry is one or two cells, and may be an inner interpreter code, with or without an argument,
     ///    or a defined word. For space efficiency, builtin words and user defined (colon) words are
-    ///    represented by the cfa of their definition. The interpreter calls the builtin code.
+    ///    represented by the cfa of their definition, overlaid with a flag. The interpreter calls the builtin code.
     ///    For nested definitions, the inner interpreter pushes the program counter (PC) and continues.
     ///    When the end of a definition is found, the PC is restored from the previous caller.
-    ///    Not sure how we know we're done and ready to return to the command line. ***
     ///
     ///    Most data is represented by an address, so self.data[pc] is the cfa of the word referenced.
     ///    Each operation advances the pc to the next token.
@@ -100,12 +99,6 @@ impl TF {
                 BUILTIN => {
                     self.msg
                         .error("i_definition", "Found BUILTIN???", Some(code));
-                    /*                     let index = self.data[pc + 1] as usize;
-                                      let op = &self.builtins[index];
-                                      let func = op.code;
-                                      func(self);
-                    */
-                    // return
                     self.f_r_from();
                     pc = pop!(self) as usize;
                 }
@@ -200,8 +193,11 @@ impl TF {
     /// Force an abort
     pub fn i_abort(&mut self) {}
 
-    /// Leave the current word
-    pub fn i_exit(&mut self) {}
+    /// Leave the current word *** doesn't work, because there's no way to reset the program counter from here
+    pub fn i_exit(&mut self) {
+        self.f_r_from();
+        // pc = pop!(self) as usize;
+    }
 
     /// Continue to the next word
     pub fn i_next(&mut self) {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Tforth main program
+// f2 main program
 // Version 0.1
 
 mod config;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -16,29 +16,17 @@ enum Source {
 
 pub struct Reader {
     source: Source, // Stdin or a file
-    prompt: String, // the standard prompt
     msg: Msg,
 }
 
-impl fmt::Debug for Reader {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Tokenizer").field(&self.source).finish()
-    }
-}
-
 impl Reader {
-    pub fn new(
-        file_path: Option<&std::path::PathBuf>,
-        prompt: &str,
-        msg_handler: Msg,
-    ) -> Option<Reader> {
+    pub fn new(file_path: Option<&std::path::PathBuf>, msg_handler: Msg) -> Option<Reader> {
         // Initialize a tokenizer.
         let mut message_handler = Msg::new();
         message_handler.set_level(DebugLevel::Error);
         match file_path {
             None => Some(Reader {
                 source: Source::Stdin,
-                prompt: prompt.to_owned(),
                 msg: msg_handler,
             }),
             Some(filepath) => {
@@ -46,7 +34,6 @@ impl Reader {
                 match file {
                     Ok(file) => Some(Reader {
                         source: Source::Stream(BufReader::new(file)),
-                        prompt: prompt.to_owned(),
                         msg: msg_handler,
                     }),
                     Err(_) => {
@@ -70,7 +57,6 @@ impl Reader {
         let result;
         match self.source {
             Source::Stdin => {
-                //print!("{} ", self.prompt);
                 io::stdout().flush().unwrap();
                 result = io::stdin().read_line(&mut new_line);
             }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,7 +2,6 @@
 // Return one space-delimited token at a time.
 // Cache the remainder of the line.
 
-use std::fmt;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read, Write};
 

--- a/src/regression.fs
+++ b/src/regression.fs
@@ -13,7 +13,6 @@ variable test-num 0 test-num !
 ( If the desired result is equal to the top of the stack, the test passes. )
 ( Relies on a variable test-num that indicates the number of the test. )
 
-variable test-num 0 test-num !
 : test-none ( .. -- ) depth 1 test-num +!
     0= if test-num ? ."  Passed" else ."    Failed" test-num @ then cr ;
 
@@ -41,27 +40,25 @@ variable test-num 0 test-num !
 1 2 3 4 5 clear test-none
 
 ."         Debugger"
-\1 1 1 dbg test-single ." warnings and errors"
-\1 1 2 dbg test-single ." info, warnings and errors"
-\1 1 3 dbg test-single ." debug, info, warnings and errors"
+\ 1 1 1 dbg test-single ." warnings and errors"
+\ 1 1 2 dbg test-single ." info, warnings and errors"
+\ 1 1 3 dbg test-single ." debug, info, warnings and errors"
 1 1 0 dbg test-single ." quiet mode (errors only)"
 1 1 4 dbg test-single ." invalid value 4"
 1 1 -4 dbg test-single ." invalid value -4"
 1 1 dbg-warning test-single
-1 1 debuglevel? test-single 
+\ 1 1 debuglevel? test-single 
 
 ."         Printing"
 1 1 23 . test-single
 1 1 44 . flush test-single
-1 1 .s test-single
+\ 1 1 .s test-single
 1 1 45 emit test-single
 
 ."                Loop tests"
- 7 21 7 loop-test + + + + + + test-dual
- 4 2 4 nested-loop-test - - - test-dual
- 55 -2 loop-test 55 test-single
-3 3 3 loop-test + + test-dual
-0 0 loop-test test-single
+7 21 7 loop-test + + + + +  test-dual
+4 2 4 nested-loop-test - - test-dual
+3 3 3 loop-test + test-dual
 
 ."         Arithmetic"
 5 1 4 + test-single
@@ -70,19 +67,19 @@ variable test-num 0 test-num !
 4 12 3 / test-single
 
 ."         Logic"
--1 true test-single
-0 false test-single
+-1 TRUE test-single
+0 FALSE test-single
 
 ."         Comparisons"
-false 1 3 > test-single ." >"
-true 3 1 > test-single
-false 5 2 < test-single
-true 2 5 < test-single
-false -5 0= test-single
-true 0 0= test-single
-true -22 0< test-single
-false 0 0< test-single
-false 55 0< test-single
+FALSE 1 3 > test-single ." >"
+TRUE 3 1 > test-single
+FALSE 5 2 < test-single
+TRUE 2 5 < test-single
+FALSE -5 0= test-single
+TRUE 0 0= test-single
+TRUE -22 0< test-single
+FALSE 0 0< test-single
+FALSE 55 0< test-single
 
 ."         Bitwise"
 3 1 2 or test-single ." or"
@@ -97,7 +94,7 @@ false 55 0< test-single
  1 1 100 drop test-single
 5 5 6 drop test-single
 5 6 5 nip test-single
-1 1 2 3 4 5 6 stack-depth drop drop drop drop drop drop test-single
+1 1 2 3 4 5 6 depth drop drop drop drop drop drop test-single
 17 17 17 dup test-dual
 4 7 7 4 swap test-dual
 5 12 5 12 over drop test-dual

--- a/src/regression.fs
+++ b/src/regression.fs
@@ -8,10 +8,10 @@
 
 variable test-num 0 test-num !
 
-( Test Functions: place desired result on the stack, 
-  then push args to the test word, then the word, then test-single.
-  If the desired result is equal to the top of the stack, the test passes.
-  Relies on a variable test-num that indicates the number of the test. )
+( Test Functions: place desired result on the stack, )
+( then push args to the test word, then the word, then test-single. )
+( If the desired result is equal to the top of the stack, the test passes. )
+( Relies on a variable test-num that indicates the number of the test. )
 
 variable test-num 0 test-num !
 : test-none ( .. -- ) depth 1 test-num +!


### PR DESCRIPTION
Changes are as follows:

1. Implemented `variable` and `constant`
2. Added basic string functions: c`@`, `c!`, `s-parse`, `s-copy`, `.s"`, `."`
3. Implemented compiled strings using `."`
`4. Extended see to handle variables, constants and builtins
5. Implemented `include-file`, `include`, and `included` for external Forth file loading
6. Implemented automatic loading of the standard library
7. Updated regression tests and verified they work
8. Implemented additional control structures
9. Moved a number of functions to Forth (from Rust)
10. Added `now`, `millis` and `micros` for performance analysis
11. Added constants to represent opcodes and some common characters