### PR TITLE
Documentation and stepper / tracer improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,13 @@
                 }
             },
             "args": [],
-            "cwd": "${workspaceFolder}"
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/target/debug/${workspaceFolderBasename}",
+            "terminal": "external",
+            "stopOnEntry": false,
+            "sourceLanguages": [
+                "rust"
+            ],
         },
         {
             "type": "lldb",

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crate::messages::DebugLevel;
 
 use ::clap::{arg, Command};
 
-const VERSION: &str = "alpha.24.3.1";
+const VERSION: &str = "alpha.24.3.5";
 const WELCOME_MESSAGE: &str = "Welcome to f2.";
 const EXIT_MESSAGE: &str = "Finished";
 const DEFAULT_CORE: [&str; 2] = ["~/.f2/corelib.fs", "src/corelib.fs"];

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,8 @@ impl Config {
         }
     }
 
+    /// process_args handles command line argument processing using the clap library
+    ///
     pub fn process_args(&mut self) -> &Config {
         // process arguments
         // let msg = Msg::new(); // Create a message handler for argument errors
@@ -81,6 +83,9 @@ impl Config {
         self
     }
 
+    /// run_forth is the main entry point that performs the cold start operations, loads library files,
+    ///     and hands off control to the main interpreter loop
+    ///
     pub fn run_forth(&mut self) {
         // create and run the interpreter
         // return when finished

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -39,13 +39,13 @@
 
 : text BL parse ;                                   \ Parser shortcut for space-delimited tokens
 : s-parse tmp @ swap parse-to ;                     \ Same as text, but loads to tmp instead of pad
-: s" ( -- s u ") tmp @ '"' parse-to ;         \ Places a double-quoted string in tmp
+: s" ( -- s u ") tmp @ '"' parse-to ;               \ Places a double-quoted string in tmp
 
 ( File reader functions )
 : included tmp @ include-file ; \ include-file uses a string pointer on the stack to load a file
 : include tmp @ 32 parse-to included ;
 
-: [ FALSE state ! ; immediate                                \ Turns compile mode off
+: [ FALSE state ! ; immediate                       \ Turns compile mode off
 : ] TRUE state ! ;                                  \ Turns compile mode on
 
 \ Untested implementation of recursion support
@@ -97,24 +97,39 @@
 : space ( -- ) BL emit ;
 : spaces ( n -- ) for space next ;
 
-: type ( s -- ) ADDRESS_MASK and dup c@ dup rot + swap for dup i - 1+ c@ emit next drop BL emit ;
+: type ( s -- )                                 \ Print from the string pointer on the stack
+    ADDRESS_MASK and                            \ Wipe out any flags
+    dup c@ dup rot + swap                       \ Get the length to drive the for loop
+    for 
+        dup i - 1+ c@ emit                      \ Output one character
+    next 
+        drop BL emit ;                          \ Emit a final space
 
-: tell ( s l -- ) swap ADDRESS_MASK and swap for dup i - 1+ c@ emit next drop BL emit ;
+: tell ( s l -- )                               \ like type, but length is provided: useful for substrings
+    swap ADDRESS_MASK and swap 
+    for 
+        dup i - 1+ c@ emit 
+    next 
+        drop BL emit ;
 
-: .tmp tmp @ type ;
-: .pad pad @ type ;
-: ." state @
+: .tmp tmp @ type ;                             \ Print the tmp buffer
+: .pad pad @ type ;                             \ Print the pad buffer
+: ." state @                                    \ Compile or print a string
     if
-        STRLIT , 
+        STRLIT ,                                \ Compilation section
         s" drop s-create ,
         ['] type ,
     else
-        s" drop type
+        s" drop type                            \ Print section
     then ; immediate
 
 \ Implementation of word
 : .word ( bp -- bp ) dup dup '[' emit . 1+ @ type ']' emit space @ ;             \ prints a word name, given the preceding back pointer
-: words ( -- ) here @ 1- @ begin .word dup not until ;   \ loops through the words in the dictionary
+: words ( -- ) 
+    here @ 1- @                                 \ Get the starting point: the top back pointer
+    begin                                       \ loops through the words in the dictionary
+        .word dup not                           \ print a word and test the next pointer
+    until ;   
 
 \ Stepper controls
 : step-on -1 stepper ! ;
@@ -127,6 +142,13 @@
 : dbg-warning 1 dbg ;
 : dbg-quiet 0 dbg ;
 : debug show-stack step-on ;
+
+: abort" s" .tmp space abort ;
+
+: delete ( -- )                                 \ delete the most recent definition
+    here @ 1- @ dup 1+ here !                   \ resets HERE to the previous back pointer
+    @ 1+ dup context ! last !                   \ resets CONTEXT and LAST
+    ;
 
 \ : ?stack depth 0= if ." Stack underflow" abort then ;
 
@@ -146,7 +168,8 @@
 ( Application functions )
 
 : _fac ( r n -- r )   \ Helper function that does most of the work.
-    dup if 
+    dup 
+    if 
         tuck * swap 1 - recurse 
     else 
         drop 
@@ -154,10 +177,10 @@
 
 : fac ( n -- n! )   \ Calculates factorial of a non-negative integer. No checks for stack or calculation overflow.
     dup 
-        if 
-            1 swap _fac 
-        else 
-            drop 1 
-        then ;
+    if 
+        1 swap _fac 
+    else 
+        drop 1 
+    then ;
 
- cr cr ." Library loaded." cr
+ cr ." Library loaded." cr

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -116,6 +116,8 @@
 : .word ( bp -- bp ) dup dup '[' emit . 1+ @ type ']' emit space @ ;             \ prints a word name, given the preceding back pointer
 : words ( -- ) here @ 1- @ begin .word dup not until ;   \ loops through the words in the dictionary
 
+: step-on TRUE stepper ! ;
+: step-off FALSE stepper ! ;
 : dbg-debug 3 dbg ;
 : dbg-info 2 dbg ;
 : dbg-warning 1 dbg ;

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -95,7 +95,7 @@
 : abs ( n -- n | -n ) dup 0 < if -1 * then ;
 
 : space ( -- ) BL emit ;
-: spaces ( n -- ) 1- for space next ;
+: spaces ( n -- ) for space next ;
 
 : type ( s -- ) ADDRESS_MASK and dup c@ dup rot + swap for dup i - 1+ c@ emit next drop BL emit ;
 
@@ -116,8 +116,12 @@
 : .word ( bp -- bp ) dup dup '[' emit . 1+ @ type ']' emit space @ ;             \ prints a word name, given the preceding back pointer
 : words ( -- ) here @ 1- @ begin .word dup not until ;   \ loops through the words in the dictionary
 
-: step-on TRUE stepper ! ;
-: step-off FALSE stepper ! ;
+\ Stepper controls
+: step-on -1 stepper ! ;
+: step-off 0 stepper ! ;
+: trace-on 1 stepper ! ;
+: trace-off 0 stepper ! ;
+
 : dbg-debug 3 dbg ;
 : dbg-info 2 dbg ;
 : dbg-warning 1 dbg ;

--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -4,6 +4,18 @@
 
 1 dbg \ set debuglevel to warnings and errors
 
+\ here points to the slot where the new back pointer goes
+\ last and context point to the previous word's name field address
+
+: .close (  -- )                      \ terminate a definition, writing a back pointer and updating context, last, and here
+        last @ 1 - here !             \ write the new back pointer
+        here @ dup last ! context !   \ update LAST and CONTEXT
+        here @ 1 + here !                  \ increment HERE over the back pointer
+        ;
+
+: const ( n -- ) create 1002 , ,      \ v constant <name> creates a constant with value v
+    .close ;          
+
 0 constant FALSE
 -1 constant TRUE
 
@@ -129,7 +141,8 @@
     here @ 1- @                                 \ Get the starting point: the top back pointer
     begin                                       \ loops through the words in the dictionary
         .word dup not                           \ print a word and test the next pointer
-    until ;   
+    until 
+        drop ;   
 
 \ Stepper controls
 : step-on -1 stepper ! ;
@@ -145,10 +158,17 @@
 
 : abort" s" .tmp space abort ;
 
-: delete ( -- )                                 \ delete the most recent definition
+: forget-last ( -- )                            \ delete the most recent definition
     here @ 1- @ dup 1+ here !                   \ resets HERE to the previous back pointer
     @ 1+ dup context ! last !                   \ resets CONTEXT and LAST
     ;
+
+: forget ( <name> )                             \ delete <name> and any words since
+    ' dup if 
+        1- dup here !
+        1- @ 1+ dup context ! last ! 
+    else
+        drop ;
 
 \ : ?stack depth 0= if ." Stack underflow" abort then ;
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -68,7 +68,7 @@ pub struct TF {
     pub msg: Msg,
     pub reader: Vec<Reader>, // allows for nested file processing
     pub show_stack: bool,    // show the stack at the completion of a line of interaction
-    pub step_mode: bool,
+    pub stepper_ptr: usize,
     pub timer: Instant, // for timing things
 }
 
@@ -111,7 +111,7 @@ impl TF {
                 msg: Msg::new(),
                 reader: Vec::new(),
                 show_stack: true,
-                step_mode: false,
+                stepper_ptr: 0,
                 timer: Instant::now(),
             };
             interpreter.reader.push(reader);
@@ -171,43 +171,6 @@ impl TF {
     pub fn should_exit(&self) -> bool {
         // Method to determine if we should exit
         self.exit_flag
-    }
-
-    fn step(&mut self) {
-        // controls step / debug functions
-        if self.step_mode {
-            /*             match &self.token_ptr.1 {
-                          ForthToken::Integer(num) => print!("{num}: Step> "),
-                          ForthToken::Float(num) => print!("f{num}: Step> "),
-                          ForthToken::Operator(op) => print!("{op}: Step> "),
-                          ForthToken::Jump(name, offset) => {
-                              print!("{name}:{}: Step> ", offset);
-                          }
-                          ForthToken::Forward(info) => {
-                              print!("{}{}: Step> ", info.word, info.tail);
-                          }
-                          ForthToken::Builtin(name, code) => print!("{}:{:?}", name, code),
-                          ForthToken::Definition(name, _def) => print!("{name} "),
-                          ForthToken::Empty => print!("ForthToken::Empty: Step> "),
-                          ForthToken::Variable(n, v) => print!("{}={}", n, v),
-                          _ => print!("variable or constant???"),
-                      }
-                      io::stdout().flush().unwrap();
-                      match self.parser.reader.read_char() {
-                          Some('s') => {
-                              self.print_stack();
-                              self.print_return_stack();
-                          }
-                          // Some('v') => self.print_variables(),
-                          Some('a') => {
-                              self.print_stack();
-                              //self.print_variables();
-                          }
-                          Some('c') => self.step_mode = false,
-                          Some(_) | None => {}
-                      }
-            */
-        }
     }
 
     /* pub fn pack_string(&self, input: &str) -> Vec<usize> {

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -74,6 +74,7 @@ impl TF {
         self.state_ptr = self.u_make_variable("'eval");
         self.abort_ptr = self.u_make_variable("abort?");
         self.state_ptr = self.u_make_variable("state");
+        self.stepper_ptr = self.u_make_variable("stepper"); // turns the stepper on or off
         self.data[self.abort_ptr] = FALSE;
     }
 
@@ -332,8 +333,6 @@ impl TF {
             TF::f_debuglevel,
             "debuglevel ( -- ) Displays the current debug level",
         );
-        self.u_add_builtin("step-on", TF::f_step_on, "");
-        self.u_add_builtin("step-off", TF::f_step_off, "");
         self.u_add_builtin(
             ">r",
             TF::f_to_r,

--- a/src/internals/builtin.rs
+++ b/src/internals/builtin.rs
@@ -6,10 +6,12 @@
 use crate::engine::{BUILTIN_MASK, FALSE, STR_START, TF, TIB_START, VARIABLE};
 use crate::engine::{PAD_START, TMP_START};
 
+// The mechanism for storing and calling function pointers
 pub trait BuiltinCall {
     fn call(&mut self);
 }
 
+// The internal format for builtins: a name, code pointer, and documentation string for use by SEE
 pub struct BuiltInFn {
     pub name: String,
     pub code: for<'a> fn(&'a mut TF),
@@ -27,6 +29,10 @@ impl BuiltInFn {
 }
 
 impl TF {
+    /// u_insert_variables builds the initial set of variables that are visible in Forth and Rust
+    ///
+    /// They use pointers stored in the main interpreter struct, but the values are stored in Forth user space
+    ///
     pub fn u_insert_variables(&mut self) {
         // install system variables in data area
         // hand craft S-HERE (free string pointer) so write_string() can work
@@ -78,7 +84,8 @@ impl TF {
         self.data[self.abort_ptr] = FALSE;
     }
 
-    /// Insert Forth code into the dictionary
+    /// Insert Forth code into the dictionary by causing the reader to interpret a string
+    ///
     pub fn u_insert_code(&mut self) {
         // self.u_interpret("2 2 + .");
     }
@@ -97,7 +104,7 @@ impl TF {
         result_ptr
     }
 
-    /// make-variable Create a variable, returning the address of the variable's value
+    /// make-variable creates a variable, returning the address of the variable's value
     fn u_make_variable(&mut self, name: &str) -> usize {
         let code_ptr = self.u_make_word(&name, &[VARIABLE, 0]); // install the name
         code_ptr + 1 // the location of the variable's value
@@ -110,10 +117,11 @@ impl TF {
        }
     */
     /// u_make_word Install a new word with provided name and arguments
-    /// back link is already in place
-    /// place it HERE
-    /// update HERE and LAST
-    /// return pointer to first parameter field - the code field pointer or cfa
+    ///     back link is already in place
+    ///     place it HERE
+    ///     update HERE and LAST
+    ///     return pointer to first parameter field - the code field pointer or cfa
+    ///
     fn u_make_word(&mut self, name: &str, args: &[i64]) -> usize {
         let back = self.data[self.here_ptr] as usize - 1; // the top-of-stack back pointer's location
         let mut ptr = back + 1;
@@ -129,6 +137,12 @@ impl TF {
         back + 2 // address of first parameter field
     }
 
+    /// u_add_builtin creates a builtin record with function pointer etc. and links it to a word in the dictionary
+    ///     The dual representation is used because of strong typing - it would be great to store the
+    ///     function pointer directly in user space, but it would require ugly casting (if it's even possible).
+    ///     Also, calling a function via an address in data space is going to cause a crash if the data space
+    ///     pointer is incorrect.
+    ///
     fn u_add_builtin(&mut self, name: &str, code: for<'a> fn(&'a mut TF), doc: &str) {
         self.builtins
             .push(BuiltInFn::new(name.to_owned(), code, doc.to_string()));
@@ -137,8 +151,9 @@ impl TF {
         self.u_make_word(name, &[cfa as i64]);
     }
 
+    /// Set up all the words that are implemented in Rust
+    ///     Each one gets a standard dictionary reference, and a slot in the builtins data structure.
     pub fn add_builtins(&mut self) {
-        // Inner interpreters occupy the addresses lower than 100
         self.u_add_builtin(
             "_builtin",
             TF::i_builtin,
@@ -191,11 +206,7 @@ impl TF {
             "_next opcode -- end of word - continue to the next one",
         );
         // Start of normal functions
-        self.u_add_builtin(
-            "f_marker",
-            TF::f_marker,
-            "marker <name> ( -- ) Places a named marker in the dictionary, to be used by FORGET",
-        );
+
         self.u_add_builtin("+", TF::f_plus, "+ ( j k -- j+k ) Push j+k on the stack");
         self.u_add_builtin("-", TF::f_minus, "- ( j k -- j+k ) Push j-k on the stack");
         self.u_add_builtin("*", TF::f_times, "* ( j k -- j-k ) Push  -k on the stack");

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -69,7 +69,6 @@ impl TF {
     pub fn f_quit(&mut self) {
         self.set_program_counter(0);
         self.f_abort();
-        print!(" ok ");
         loop {
             if self.should_exit() {
                 break;
@@ -77,10 +76,12 @@ impl TF {
                 self.set_abort_flag(false);
                 self.f_query();
                 self.f_eval(); // interpret the contents of the line
-                if self.show_stack {
-                    self.f_dot_s();
+                if self.reader.len() == 1 {
+                    if self.show_stack {
+                        self.f_dot_s();
+                    }
+                    print!(" ok ");
                 }
-                print!(" ok ");
                 self.f_flush();
             }
         }

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -447,7 +447,7 @@ impl TF {
         let length = pop!(self) as usize;
         let source = pop!(self) as usize;
         // assuming both are counted, we begin with the count byte. Length should match the source count byte
-        for i in (0..=length) {
+        for i in 0..=length {
             self.strings[dest + i] = self.strings[source + i];
         }
         push!(self, dest as i64);
@@ -553,16 +553,6 @@ impl TF {
         }
     }
     */
-
-    /// u_write_word compiles a token into the current definition at HERE
-    ///              updating HERE afterwards
-    ///              the address of the (defined) word is on the stack
-    ///              we compile a pointer to the word's inner interpreter
-    pub fn u_write_word(&mut self, word_addr: i64) {
-        if stack_ok!(self, 1, "u-interpret") {
-            self.data[self.here_ptr] = word_addr;
-        }
-    }
 
     /// Return a string from a Forth string address
     pub fn u_get_string(&mut self, addr: usize) -> String {

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -267,8 +267,10 @@ impl TF {
     /// UNIQUE? (s -- s )
     /// Checks the dictionary to see if the word pointed to is defined.
     pub fn f_q_unique(&mut self) {
+        self.f_dup();
         self.f_find();
         let result = pop!(self);
+        pop!(self);
         if result == TRUE {
             self.msg
                 .warning("unique?", "Overwriting existing definition", None::<bool>);

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -40,7 +40,8 @@ macro_rules! push {
 
 impl TF {
     /// immediate ( -- ) sets the immediate flag on the most recently defined word
-    /// Context pointer links to the most recent name field
+    ///     Context pointer links to the most recent name field
+    ///
     pub fn f_immediate(&mut self) {
         let mut str_addr = self.data[self.data[self.context_ptr] as usize] as usize;
         str_addr |= IMMEDIATE_MASK;
@@ -48,6 +49,7 @@ impl TF {
     }
 
     /// immediate? ( cfa -- T | F ) Determines if a word is immediate or not
+    ///
     pub fn f_immediate_q(&mut self) {
         if stack_ok!(self, 1, "immediate?") {
             let cfa = pop!(self) as usize;
@@ -58,6 +60,9 @@ impl TF {
         }
     }
 
+    /// abort empties the stack, resets any pending operations, and returns to the prompt
+    ///     There is a version called abort" implemented in Forth, which prints an error message
+    ///
     pub fn f_abort(&mut self) {
         // empty the stack, reset any pending operations, and return to the prompt
         self.msg
@@ -66,8 +71,9 @@ impl TF {
         self.set_abort_flag(true);
     }
 
+    /// quit is the main loop in Forth, reading from the input stream and dispatching for evaluation
+    ///     quit also issues the prompt and checks for a shutdown (exit) condition
     pub fn f_quit(&mut self) {
-        self.set_program_counter(0);
         self.f_abort();
         loop {
             if self.should_exit() {
@@ -116,8 +122,7 @@ impl TF {
         }
     }
 
-    /// EVAL ( -- ) Interprets a line of tokens from TIB
-    //             self.f_find(); // (s -- nfa, cfa, T | s F )
+    /// EVAL ( -- ) Interprets a line of tokens from the Text Input Buffer (TIB
     pub fn f_eval(&mut self) {
         loop {
             push!(self, self.data[self.pad_ptr]);
@@ -125,15 +130,15 @@ impl TF {
             self.f_parse_to(); //  ( -- b u ) get a token
             let len = pop!(self);
             if len == FALSE {
-                // u = 0 means EOL
-                pop!(self); // lose the text pointer
+                // Forth FALSE is zero, which here indicates end of line
+                pop!(self); // lose the text pointer from parse-to
                 break;
             } else {
                 // we have a token
                 if self.get_compile_mode() {
-                    self.f_d_compile(); // ( s -- )
+                    self.f_d_compile();
                 } else {
-                    self.f_d_interpret(); // ( s -- )
+                    self.f_d_interpret();
                 }
             }
         }
@@ -182,6 +187,7 @@ impl TF {
     /// $INTERPRET ( s -- ) executes a token whose string address is on the stack.
     ///            If not a word, try to convert to a number
     ///            If not a number, ABORT.
+    ///
     pub fn f_d_interpret(&mut self) {
         if stack_ok!(self, 1, "$interpret") {
             let token_addr = top!(self);
@@ -205,7 +211,8 @@ impl TF {
     }
 
     /// FIND (s -- cfa T | s F ) Search the dictionary for the token indexed through s.
-    /// If not found, return the string address so NUMBER? can look at it
+    ///     If not found, return the string address so NUMBER? can look at it
+    ///
     pub fn f_find(&mut self) {
         if stack_ok!(self, 1, "find") {
             let mut result = false;
@@ -238,6 +245,7 @@ impl TF {
 
     /// number? ( s -- n T | a F ) tests a string to see if it's a number;
     /// leaves n and flag on the stack: true if number is ok.
+    ///
     pub fn f_number_q(&mut self) {
         let buf_addr = pop!(self);
         let numtext = self.u_get_string(buf_addr as usize);
@@ -252,12 +260,16 @@ impl TF {
     }
 
     /// f_comma ( n -- ) compile a value into a definition
+    ///     Takes the top of the stack and writes it to the next free location in data space
     pub fn f_comma(&mut self) {
         self.data[self.data[self.here_ptr] as usize] = pop!(self);
         self.data[self.here_ptr] += 1;
     }
 
     /// f_literal ( n -- ) compile a literal number with it's inner interpreter code pointer
+    ///     Numbers are represented in compiled functions with two words: the LITERAL constant, and the value
+    ///     The value comes from the stack.
+    ///
     pub fn f_literal(&mut self) {
         push!(self, LITERAL);
         self.f_comma();
@@ -265,7 +277,8 @@ impl TF {
     }
 
     /// UNIQUE? (s -- s )
-    /// Checks the dictionary to see if the word pointed to is defined.
+    ///     Checks the dictionary to see if the word pointed to is defined.
+    ///     No stack impact - it's just offering a warning.
     pub fn f_q_unique(&mut self) {
         self.f_dup();
         self.f_find();
@@ -278,9 +291,10 @@ impl TF {
     }
 
     /// (') (TICK) <name> ( -- a | FALSE ) Searches for a word, places cfa on stack if found; otherwise FALSE
-    /// Looks for a (postfix) word in the dictionary
-    /// places it's execution token / address on the stack
-    /// Pushes 0 if not found
+    ///     Looks for a (postfix) word in the dictionary
+    ///     places it's execution token / address on the stack
+    ///     Pushes 0 if not found
+    ///
     pub fn f_tick_p(&mut self) {
         push!(self, self.data[self.pad_ptr]);
         push!(self, ' ' as i64);
@@ -298,9 +312,11 @@ impl TF {
     }
 
     /// (parse) - ( b u c -- b u delta )
-    /// Find a c-delimited token in the string buffer at b, buffer len u.
-    /// Return the pointer to the buffer, the length of the token,
-    /// and the offset from the start of the buffer to the start of the token.
+    ///     Find a c-delimited token in the string buffer at b, buffer len u.
+    ///     This is the heart of the parsing engine.
+    ///     Return the pointer to the buffer, the length of the token,
+    ///     and the offset from the start of the buffer to the start of the token.
+    ///
     pub fn f_parse_p(&mut self) {
         if stack_ok!(self, 3, "(parse)") {
             let delim = pop!(self) as u8 as char;
@@ -336,6 +352,8 @@ impl TF {
     /// need to check if TIB is empty
     /// if delimiter = 1, get the rest of the TIB
     /// Update >IN as required, and set #TIB to zero if the line has been consumed
+    /// The main text parser that reads tokens from the TIB for interactive operations
+    ///
     pub fn f_parse_to(&mut self) {
         if stack_ok!(self, 2, "parse") {
             let delim: i64 = pop!(self);
@@ -380,6 +398,10 @@ impl TF {
         }
     }
 
+    /// : (colon) starts the creation of a compiled function
+    ///     It sets compile mode, creates the name header, and writes the constant that determines how
+    ///     the word is to be processed at run time.
+    ///
     pub fn f_colon(&mut self) {
         self.set_compile_mode(true);
         self.f_create(); // gets the name and makes a new dictionary entry
@@ -388,9 +410,10 @@ impl TF {
     }
 
     /// ; terminates a definition, writing the cfa for EXIT, and resetting to interpret mode
-    ///   It has to write the exit code word, and add a back pointer
-    ///   It also has to update HERE and CONTEXT.
-    ///   Finally it switches out of compile mode
+    ///     It has to write the exit code word, and add a back pointer
+    ///     It also has to update HERE and CONTEXT.
+    ///     Finally it switches out of compile mode
+    ///
     pub fn f_semicolon(&mut self) {
         push!(self, EXIT);
         self.f_comma();
@@ -401,7 +424,8 @@ impl TF {
     }
 
     /// CREATE <name> ( -- ) makes a new dictionary entry, using a postfix name
-    /// References HERE, and assumes back pointer is in place already
+    ///     References HERE, and assumes back pointer is in place already
+    ///     create updates the three definition-related pointers: HERE, CONTEXT and LAST
     pub fn f_create(&mut self) {
         push!(self, self.data[self.pad_ptr]);
         push!(self, ' ' as i64);
@@ -419,6 +443,9 @@ impl TF {
     }
 
     /// variable <name> ( -- ) Creates a new variable in the dictionary
+    ///     This is a good candidate for shifting to Forth
+    ///     Variables use three words: a name pointer, the VARIABLE token, and the value
+    ///
     pub fn f_variable(&mut self) {
         self.f_create(); // gets a name and makes a name field in the dictionary
         push!(self, VARIABLE);
@@ -431,6 +458,8 @@ impl TF {
     }
 
     /// constant <name> ( n -- ) Creates and initializez a new constant in the dictionary
+    ///     Very similar to variables, except that their value is not intended to be changed
+    ///
     pub fn f_constant(&mut self) {
         if stack_ok!(self, 1, "constant") {
             self.f_create();
@@ -444,6 +473,8 @@ impl TF {
     }
 
     /// f_pack_d ( source len dest -- dest ) builds a new counted string from an existing counted string.
+    ///     Used by CREATE
+    ///
     pub fn f_smove(&mut self) {
         let dest = pop!(self) as usize;
         let length = pop!(self) as usize;
@@ -456,6 +487,8 @@ impl TF {
     }
 
     /// see <name> ( -- ) prints the definition of a word
+    ///     Taking a postfix word name (normally used interactively), this is the Forth decompiler.
+    ///
     pub fn f_see(&mut self) {
         self.f_tick_p(); // finds the address of the word
         let cfa = pop!(self);
@@ -556,7 +589,9 @@ impl TF {
     }
     */
 
-    /// Return a string from a Forth string address
+    /// u_get_string returns a string from a Forth string address
+    ///     Assumes the source string is counted (i.e. has its length in the first byte)
+    ///
     pub fn u_get_string(&mut self, addr: usize) -> String {
         let str_addr = (addr & ADDRESS_MASK) + 1; //
         let last = str_addr + self.strings[addr] as usize;
@@ -567,7 +602,8 @@ impl TF {
         result
     }
 
-    /// Save a counted string to a Forth string address
+    /// u_set_string saves a counted string to a Forth string address
+    ///
     pub fn u_set_string(&mut self, addr: usize, string: &str) {
         let str_addr = addr & ADDRESS_MASK;
         self.strings[str_addr] = string.len() as u8 as char; // count byte
@@ -577,8 +613,9 @@ impl TF {
     }
 
     /// copy a string from a text buffer to a counted string
-    /// Typically used to copy to PAD from TIB
-    /// Can work with source strings counted or uncounted
+    ///     Typically used to copy to PAD from TIB
+    ///     Can work with source strings counted or uncounted
+    ///
     pub fn u_str_copy(&mut self, from: usize, to: usize, length: usize, counted: bool) {
         self.strings[to] = length as u8 as char; // write count byte
         let offset = if counted { 1 } else { 0 };
@@ -589,6 +626,7 @@ impl TF {
 
     /// Compare two Forth (counted) strings
     /// First byte is the length, so we'll bail quickly if they don't match
+    ///
     pub fn u_str_equal(&mut self, s_addr1: usize, s_addr2: usize) -> bool {
         for i in 0..=self.strings[s_addr1] as usize {
             if self.strings[s_addr1 + i] != self.strings[s_addr2 + i] {
@@ -599,6 +637,7 @@ impl TF {
     }
 
     /// copy a string slice into string space
+    ///    
     pub fn u_save_string(&mut self, from: &str, to: usize) {
         self.strings[to] = from.len() as u8 as char; // count byte
         for (i, c) in from.chars().enumerate() {

--- a/src/internals/console.rs
+++ b/src/internals/console.rs
@@ -97,6 +97,7 @@ impl TF {
     }
 
     /// QUERY ( -- ) Load a new line of text into the TIB
+    ///     
     pub fn f_query(&mut self) {
         push!(self, self.data[self.tib_ptr]);
         push!(self, BUF_SIZE as i64 - 1);
@@ -106,8 +107,11 @@ impl TF {
         pop!(self); // we don't need the address
     }
 
-    // output
+    // output functions
 
+    /// emit ( c -- ) takes a character from the stack and prints it.
+    ///     emit will only output printable characters; others are consumed but not output.
+    ///
     pub fn f_emit(&mut self) {
         if stack_ok!(self, 1, "emit") {
             let c = pop!(self);
@@ -119,10 +123,18 @@ impl TF {
         }
     }
 
+    /// flush ( -- ) Push any characters in Rust's output buffer out.
+    ///     By default printed characters are buffered until a newline.
+    ///     This forces them out sooner
+    ///
     pub fn f_flush(&mut self) {
         io::stdout().flush().unwrap();
     }
 
+    /// . (dot) is the standard Forth word to output a number from the top of the stack
+    ///     A more correct implementation would output using the radix stored in BASE
+    ///     This is still TBD in this implementation
+    ///
     pub fn f_dot(&mut self) {
         if stack_ok!(self, 1, ".") {
             let a = pop!(self);
@@ -130,6 +142,8 @@ impl TF {
         }
     }
 
+    /// .s ( -- ) prints a copy of the computation stack
+    ///
     pub fn f_dot_s(&mut self) {
         print!("[ ");
         for i in (self.stack_ptr..STACK_START).rev() {
@@ -138,11 +152,16 @@ impl TF {
         print!("] ");
     }
 
+    /// cr ( -- ) prints a newline. Only required because EMIT will not output control characters
+    ///
     pub fn f_cr(&mut self) {
         println!("");
     }
 
     /// s" ( -- ) get a string and place it in TMP
+    ///     TMP is a buffer used for staging strings
+    ///     PAD is another string buffer, but it is used for token parsing
+    ///
     pub fn f_s_quote(&mut self) {
         push!(self, self.data[self.tmp_ptr]);
         push!(self, '"' as i64);
@@ -153,9 +172,14 @@ impl TF {
 
     // file i/o
 
+    /// r/w ( -- ) sets the file mode for file operations
+    ///
     pub fn f_r_w(&mut self) {
         self.file_mode = FileMode::ReadWrite;
     }
+
+    /// r/w ( -- ) sets the file mode for file operations
+    ///
     pub fn f_r_o(&mut self) {
         self.file_mode = FileMode::ReadOnly;
     }

--- a/src/internals/debug.rs
+++ b/src/internals/debug.rs
@@ -1,6 +1,6 @@
 // Debugging help
 
-use crate::engine::{STACK_START, TF};
+use crate::engine::{FALSE, STACK_START, TF, TRUE};
 use crate::messages::DebugLevel;
 
 macro_rules! stack_ok {
@@ -60,11 +60,30 @@ impl TF {
         println!("DebugLevel is {:?}", self.msg.get_level());
     }
 
-    pub fn f_step_on(&mut self) {
-        self.step_mode = true;
-    }
-
-    pub fn f_step_off(&mut self) {
-        self.step_mode = false;
+    pub fn u_step(&mut self, address: usize, is_builtin: bool) {
+        let mut c;
+        if self.data[self.stepper_ptr] == TRUE {
+            print!("Step> ");
+            self.f_flush();
+            loop {
+                self.f_key();
+                c = pop!(self) as u8 as char;
+                if c != '\n' {
+                    break;
+                }
+            }
+            match c {
+                's' => {
+                    self.f_dot_s();
+                    if is_builtin {
+                        println!(" {} ", &self.builtins[address].name);
+                    } else {
+                        println!(" {} ", self.u_get_string(self.data[address - 1] as usize));
+                    }
+                }
+                'c' => self.data[self.stepper_ptr] = FALSE,
+                _ => println!("Stepper: 's' for show, 'c' for continue."),
+            }
+        }
     }
 }

--- a/src/internals/debug.rs
+++ b/src/internals/debug.rs
@@ -31,20 +31,27 @@ macro_rules! push {
 }
 
 impl TF {
+    /// show-stack ( -- ) turns on stack printing at the time the prompt is issued
+    ///
     pub fn f_show_stack(&mut self) {
         self.show_stack = true;
     }
 
+    /// hide-stack ( -- ) turns off stack printing at the time the prompt is issued
+    ///
     pub fn f_hide_stack(&mut self) {
         self.show_stack = false;
     }
 
     /// DEPTH - print the number of items on the stack
+    ///
     pub fn f_stack_depth(&mut self) {
         let depth = STACK_START - self.stack_ptr;
         push!(self, depth as i64);
     }
 
+    /// dbg ( n -- ) sets the current debug level used by the message module
+    ///
     pub fn f_dbg(&mut self) {
         if stack_ok!(self, 1, "dbg") {
             match pop!(self) {
@@ -60,6 +67,13 @@ impl TF {
         println!("DebugLevel is {:?}", self.msg.get_level());
     }
 
+    /// u_step provides the step / trace functionality
+    ///     called from inside the definition interpreter
+    ///     it is driven by the STEPPER variable:
+    ///     STEPPER = 0 => stepping is off
+    ///     STEPPER = -1 => single step
+    ///     STEPPER = 1 => trace mode, printing the stack and current word before each operation
+    ///
     pub fn u_step(&mut self, address: usize, is_builtin: bool) {
         let mode = self.data[self.stepper_ptr];
         let mut c = '\n';

--- a/src/internals/general.rs
+++ b/src/internals/general.rs
@@ -54,15 +54,22 @@ macro_rules! pop1_push1 {
     };
 }
 
+/// u_is_integer determines whether a string parses correctly as an integer
+///
 pub fn u_is_integer(s: &str) -> bool {
     s.parse::<i64>().is_ok()
 }
 
+/// u_is_float determines whether a string parses correctly as a floating point number
+///     Floating point arithmetic is currently not supported
+///
 pub fn u_is_float(s: &str) -> bool {
     s.parse::<f64>().is_ok()
 }
 
 impl TF {
+    /// Basic Forth operations on the stack.
+    ///
     pub fn f_plus(&mut self) {
         if stack_ok!(self, 2, "+") {
             let a = pop!(self);
@@ -174,6 +181,7 @@ impl TF {
         }
     }
 
+    /// @ (get) ( a -- n ) loads the value at address a onto the stack
     pub fn f_get(&mut self) {
         if stack_ok!(self, 1, "@") {
             let addr = pop!(self);
@@ -181,6 +189,8 @@ impl TF {
         }
     }
 
+    /// ! (store) ( n a -- ) stores n at address a. Generally used with variables
+    ///
     pub fn f_store(&mut self) {
         if stack_ok!(self, 2, "!") {
             let addr = pop!(self);
@@ -190,6 +200,7 @@ impl TF {
     }
 
     /// >r ( n -- ) Pops the stack, placing the value on the return stack
+    ///
     pub fn f_to_r(&mut self) {
         if stack_ok!(self, 1, ">r") {
             let value = pop!(self);
@@ -199,27 +210,32 @@ impl TF {
     }
 
     /// r> ( -- n ) Pops the return stack, pushing the value to the calculation stack
+    ///
     pub fn f_r_from(&mut self) {
         push!(self, self.data[self.return_ptr]);
         self.return_ptr += 1;
     }
 
     /// r@ ( -- n ) Gets the top value from the return stack, pushing the value to the calculation stack
+    ///
     pub fn f_r_get(&mut self) {
         push!(self, self.data[self.return_ptr]);
     }
 
     /// i ( -- n ) Pushes the current loop index to the calculation stack
+    ///
     pub fn f_i(&mut self) {
         push!(self, self.data[self.return_ptr]);
     }
 
     /// j ( -- n ) Pushes the second level (outer) loop index to the calculation stack
+    ///
     pub fn f_j(&mut self) {
         push!(self, self.data[self.return_ptr + 1]);
     }
 
     /// c@ - ( s -- c ) read a character from a string and place on the stack
+    ///
     pub fn f_c_get(&mut self) {
         if stack_ok!(self, 1, "c@") {
             let s_address = pop!(self) as usize;

--- a/src/internals/inner.rs
+++ b/src/internals/inner.rs
@@ -3,8 +3,8 @@
 /// Core functions to execute specific types of objects
 ///
 use crate::engine::{
-    ABORT, BRANCH, BRANCH0, BUILTIN, BUILTIN_MASK, CONSTANT, DEFINITION, EXIT, LITERAL, NEXT,
-    RET_START, STRLIT, TF, VARIABLE,
+    ABORT, ADDRESS_MASK, BRANCH, BRANCH0, BUILTIN, BUILTIN_MASK, CONSTANT, DEFINITION, EXIT,
+    LITERAL, NEXT, RET_START, STRLIT, TF, VARIABLE,
 };
 
 macro_rules! pop {
@@ -166,13 +166,15 @@ impl TF {
                 _ => {
                     // we have a word address
                     // see if it's a builtin:
-                    let mut builtin_flag = code as usize & BUILTIN_MASK;
+                    let builtin_flag = code as usize & BUILTIN_MASK;
+                    let address = code as usize & ADDRESS_MASK;
                     if builtin_flag != 0 {
-                        builtin_flag = code as usize & !BUILTIN_MASK;
-                        push!(self, builtin_flag as i64);
+                        self.u_step(address, true);
+                        push!(self, address as i64);
                         self.i_builtin();
                         pc += 1;
                     } else {
+                        self.u_step(address, false);
                         push!(self, pc as i64 + 1); // the return address is the next object in the list
                         self.f_to_r(); // save it on the return stack
                         pc = code as usize;

--- a/src/internals/inner.rs
+++ b/src/internals/inner.rs
@@ -74,7 +74,7 @@ impl TF {
     ///    [ index of i_definition ] [ sequence of compiled words ]
     ///
     ///    A program counter is used to step through the entries in the definition.
-    ///    Each entry is one or two cells, and may be an inner interpreter code, with or without an argument,
+    ///    Each entry is one or two cells, and may be an inner interpreter code (opcode), with or without an argument,
     ///    or a defined word. For space efficiency, builtin words and user defined (colon) words are
     ///    represented by the cfa of their definition, overlaid with a flag. The interpreter calls the builtin code.
     ///    For nested definitions, the inner interpreter pushes the program counter (PC) and continues.
@@ -82,6 +82,10 @@ impl TF {
     ///
     ///    Most data is represented by an address, so self.data[pc] is the cfa of the word referenced.
     ///    Each operation advances the pc to the next token.
+    ///
+    ///    cfa means the code field address (the address in data space of the opcode to be executed)
+    ///    nfa means the name field address (a pointer to the string naming the word)
+    ///    xt  means the execution token - a value that tells the engine what to do
     ///
     pub fn i_definition(&mut self) {
         let mut pc = pop!(self) as usize; // This is the start of the definition: first word after the inner interpreter opcode
@@ -185,24 +189,26 @@ impl TF {
     }
 
     /// Unconditional branch, used by condition and loop structures
+    ///
     pub fn i_branch(&mut self) {}
 
     /// Branch if zero, used by condition and loop structures
+    ///
     pub fn i_branch0(&mut self) {}
 
     /// Force an abort
+    ///
     pub fn i_abort(&mut self) {}
 
-    /// Leave the current word *** doesn't work, because there's no way to reset the program counter from here
+    /// Leave the current word
+    ///     *** doesn't work, because there's no way to reset the program counter from here
+    ///
     pub fn i_exit(&mut self) {
         self.f_r_from();
         // pc = pop!(self) as usize;
     }
 
     /// Continue to the next word
+    ///
     pub fn i_next(&mut self) {}
-
-    /// f_marker <name> ( -- ) sets a location for FORGET
-    ///     It creates a definition called <name> that has the effect of resetting HERE and CONTEXT       
-    pub fn f_marker(&mut self) {}
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,6 +15,8 @@ pub struct Msg {
     debug_level: DebugLevel,
 }
 
+/// A simple message processing system that allows the user to set message levels
+///
 impl Msg {
     pub fn new() -> Msg {
         Msg {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -18,7 +18,10 @@ pub struct Reader {
     msg: Msg,
 }
 
+/// Reader handles input, from stdin or files
 impl Reader {
+    /// Reader::new creates a new stream handle
+    ///
     pub fn new(file_path: Option<&std::path::PathBuf>, msg_handler: Msg) -> Option<Reader> {
         // Initialize a tokenizer.
         let mut message_handler = Msg::new();
@@ -48,6 +51,8 @@ impl Reader {
         }
     }
 
+    /// get_line returns a line of text from the input stream, or an error if unable to do so
+    ///
     pub fn get_line(&mut self) -> Option<String> {
         // Read a line, storing it if there is one
         // In interactive (stdin) mode, blocks until the user provides a line.
@@ -77,6 +82,10 @@ impl Reader {
         }
     }
 
+    /// read_char gets a single character from the input stream
+    ///     Unfortunately it blocks until the user types return, so it can't be used
+    ///     for truly interactive operations without a more complex implementation
+    ///
     pub fn read_char(&self) -> Option<char> {
         let mut buf = [0; 1];
         let mut handle = io::stdin().lock();

--- a/src/regression.fs
+++ b/src/regression.fs
@@ -36,7 +36,7 @@ variable test-num 0 test-num !
     next ;
 
 
-."         Clear has to be the first test"
+."         Clear has to be the first test" cr
 1 2 3 4 5 clear test-none
 
 ."         Debugger"
@@ -49,28 +49,28 @@ variable test-num 0 test-num !
 1 1 dbg-warning test-single
 \ 1 1 debuglevel? test-single 
 
-."         Printing"
+."         Printing" cr
 1 1 23 . test-single
 1 1 44 . flush test-single
 \ 1 1 .s test-single
 1 1 45 emit test-single
 
-."                Loop tests"
+."                Loop tests" cr
 7 21 7 loop-test + + + + +  test-dual
 4 2 4 nested-loop-test - - test-dual
 3 3 3 loop-test + test-dual
 
-."         Arithmetic"
+."         Arithmetic" cr
 5 1 4 + test-single
 -10 5 15 - test-single
 -20 2 -10 * test-single
 4 12 3 / test-single
 
-."         Logic"
+."         Logic" cr
 -1 TRUE test-single
 0 FALSE test-single
 
-."         Comparisons"
+."         Comparisons" cr
 FALSE 1 3 > test-single ." >"
 TRUE 3 1 > test-single
 FALSE 5 2 < test-single
@@ -81,7 +81,7 @@ TRUE -22 0< test-single
 FALSE 0 0< test-single
 FALSE 55 0< test-single
 
-."         Bitwise"
+."         Bitwise" cr
 3 1 2 or test-single ." or"
 2 0 2 or test-single
 0 0 0 or test-single
@@ -90,7 +90,7 @@ FALSE 55 0< test-single
 0 0 3 and test-single
 45 -1 45 and test-single
 
-."        Stack operations"
+."        Stack operations" cr
  1 1 100 drop test-single
 5 5 6 drop test-single
 5 6 5 nip test-single
@@ -100,15 +100,15 @@ FALSE 55 0< test-single
 5 12 5 12 over drop test-dual
 9 4 6 9 4 rot drop test-dual
 
-."        Variables"
+."        Variables" cr
 5 variable x 5 x ! x @ test-single
 42 variable y 40 y ! 2 y +! y @ test-single
 42 variable z 42 z ! z ? z @ test-single
 
-."        Constants"
+."        Constants" cr
 12 12 constant months months test-single \ a constant with the value 12
 
-."        Application tests"
+."        Application tests" cr
 1 0 fac test-single
 1 1 fac test-single
 6 3 fac test-single

--- a/src/regression.fs
+++ b/src/regression.fs
@@ -108,6 +108,11 @@ FALSE 55 0< test-single
 ."        Constants" cr
 12 12 constant months months test-single \ a constant with the value 12
 
+."        Engine" cr
+264 s" does-not-exist" drop ?unique test-single
+264 s" *" drop ?unique test-single
+264 s" min" drop ?unique test-single
+
 ."        Application tests" cr
 1 0 fac test-single
 1 1 fac test-single


### PR DESCRIPTION
New capabilities include:
1. Added stepper / trace capability
2. Suppressed prompts during file include
3. Added `forget-last` to delete the most recent definition
4. Added forget `<name>` to delete <name> and all words more recent
5. Updated internal function documentation
6. 